### PR TITLE
Use Fatalf instead of Fprintf+exit

### DIFF
--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/np-guard/vpc-network-config-analyzer/pkg/ibmvpc"
@@ -83,7 +84,6 @@ func _main(cmdlineArgs []string) error {
 func main() {
 	err := _main(os.Args[1:])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v. exiting...", err)
-		os.Exit(1)
+		log.Fatalf("%v. exiting...", err)
 	}
 }


### PR DESCRIPTION
Silence a warning about an unused return value in Goland; the behavior of Fatalf is equivalent.