### PR TITLE
Comparisons between expected to actual should be robust and oblivious…

### DIFF
--- a/pkg/ibmvpc/analysis_output_test.go
+++ b/pkg/ibmvpc/analysis_output_test.go
@@ -356,7 +356,7 @@ func runTestPerUseCase(t *testing.T, tt *vpcGeneralTest, c *vpcmodel.CloudConfig
 
 // comparison should be insensitive to line comparators; cleaning strings from line comparators
 func cleanStr(str string) string {
-	return strings.Replace(strings.Replace(str, "/n", "", -1), "\r", "", -1)
+	return strings.ReplaceAll(strings.ReplaceAll(str, "/n", ""), "\r", "")
 }
 
 // compareTextualResult is called in case of output mismatch, to provide more details on the difference

--- a/pkg/ibmvpc/analysis_output_test.go
+++ b/pkg/ibmvpc/analysis_output_test.go
@@ -338,7 +338,7 @@ func runTestPerUseCase(t *testing.T, tt *vpcGeneralTest, c *vpcmodel.CloudConfig
 			t.Fatalf("err: %s", err)
 		}
 		expectedOutputStr := string(expectedOutput)
-		if expectedOutputStr != actualOutput {
+		if cleanStr(expectedOutputStr) != cleanStr(actualOutput) {
 			compareTextualResult(expectedOutputStr, actualOutput)
 			t.Fatalf("output mismatch expected-vs-actual on test name: %s, use case: %d", tt.name, uc)
 		}
@@ -352,6 +352,11 @@ func runTestPerUseCase(t *testing.T, tt *vpcGeneralTest, c *vpcmodel.CloudConfig
 	}
 
 	return nil
+}
+
+// comparison should be insensitive to line comparators; cleaning strings from line comparators
+func cleanStr(str string) string {
+	return strings.Replace(strings.Replace(str, "/n", "", -1), "\r", "", -1)
 }
 
 // compareTextualResult is called in case of output mismatch, to provide more details on the difference


### PR DESCRIPTION
… to line separators which are editor dependent

solves https://github.com/np-guard/vpc-network-config-analyzer/issues/118