### PR TITLE
merging groups treating self loops as don't cares might result in an …

### DIFF
--- a/pkg/vpcmodel/groupingSelfLoop.go
+++ b/pkg/vpcmodel/groupingSelfLoop.go
@@ -309,7 +309,11 @@ func mergeSelfLoops(toMergeCouples [][2]string, oldGroupingSrcOrDst map[string][
 	for oldKey, oldLines := range oldGroupingSrcOrDst {
 		// not merged with other groups, add as is
 		if _, ok := toMergeExistingIndexes[oldKey]; !ok {
-			mergedGroupedConnLine[oldKey] = oldLines
+			if _, existInNewKeys := mergedGroupedConnLine[oldKey]; existInNewKeys {
+				mergedGroupedConnLine[oldKey] = append(mergedGroupedConnLine[oldKey], oldLines...)
+			} else {
+				mergedGroupedConnLine[oldKey] = oldLines
+			}
 		}
 	}
 	return mergedGroupedConnLine


### PR DESCRIPTION
…already existing key. In which case we must not override.

E.g:
a -> b
b -> c
a, b -> d
must result in
a, b -> a, b, d