### PR TITLE
linter: avoid printing lines of code with problems

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,3 +108,6 @@ issues:
 
 run:
   timeout: 5m
+
+output:
+  print-issued-lines: false


### PR DESCRIPTION
Print just the errors - not the code