### PR TITLE
Multi vpc grouping drawio

### DIFF
--- a/pkg/drawio/drawio_test.go
+++ b/pkg/drawio/drawio_test.go
@@ -299,7 +299,7 @@ func createZone(zones *[][]SquareTreeNodeInterface, vpc *VpcTreeNode, size int, 
 		subnets[i] = NewSubnetTreeNode(zone, sname, "", "")
 	}
 }
-func createGroup(zones *[][]SquareTreeNodeInterface, vpc *VpcTreeNode, i1, i2, j1, j2 int) SquareTreeNodeInterface {
+func createGroup(zones *[][]SquareTreeNodeInterface, i1, i2, j1, j2 int) SquareTreeNodeInterface {
 	gr := []SquareTreeNodeInterface{}
 	for i := i1; i <= i2; i++ {
 		for j := j1; j <= j2; j++ {
@@ -382,7 +382,7 @@ func createNetworkSubnetGroupingGeneric(groupsIndexes []groupIndexes) SquareTree
 	}
 	groups := make([]SquareTreeNodeInterface, len(groupsIndexes))
 	for i, index := range groupsIndexes {
-		groups[i] = createGroup(zones, vpcs[index.vpcIndex], index.z1, index.z2, index.s1, index.s2)
+		groups[i] = createGroup(zones, index.z1, index.z2, index.s1, index.s2)
 	}
 	NewConnectivityLineTreeNode(network, groups[0], groups[len(groups)-1], true, "gconn")
 

--- a/pkg/drawio/drawio_test.go
+++ b/pkg/drawio/drawio_test.go
@@ -306,7 +306,7 @@ func createGroup(zones *[][]SquareTreeNodeInterface, vpc *VpcTreeNode, i1, i2, j
 			gr = append(gr, (*zones)[i][j])
 		}
 	}
-	g := GroupedSubnetsSquare(vpc, gr)
+	g := GroupedSubnetsSquare(gr)
 	g.(*GroupSubnetsSquareTreeNode).name = fmt.Sprintf("%d-%d,%d,%d", i1, i2, j1, j2)
 	return g
 }

--- a/pkg/drawio/layout.go
+++ b/pkg/drawio/layout.go
@@ -521,7 +521,7 @@ func (ly *layoutS) setSquaresLocations() {
 		for _, groupSubnetsSquare := range cloud.(*CloudTreeNode).groupSubnetsSquares {
 			resolveSquareLocation(groupSubnetsSquare, 0, false)
 		}
-}
+	}
 	ly.resolvePublicNetworkLocations()
 	resolveSquareLocation(ly.network, 1, false)
 	if ly.subnetMode {

--- a/pkg/drawio/layout.go
+++ b/pkg/drawio/layout.go
@@ -517,11 +517,11 @@ func (ly *layoutS) setSquaresLocations() {
 					}
 				}
 			}
-			for _, groupSubnetsSquare := range vpc.(*VpcTreeNode).groupSubnetsSquares {
-				resolveSquareLocation(groupSubnetsSquare, 0, false)
-			}
 		}
-	}
+		for _, groupSubnetsSquare := range cloud.(*CloudTreeNode).groupSubnetsSquares {
+			resolveSquareLocation(groupSubnetsSquare, 0, false)
+		}
+}
 	ly.resolvePublicNetworkLocations()
 	resolveSquareLocation(ly.network, 1, false)
 	if ly.subnetMode {

--- a/pkg/drawio/squareTreeNode.go
+++ b/pkg/drawio/squareTreeNode.go
@@ -97,7 +97,7 @@ func (tn *PublicNetworkTreeNode) NotShownInDrawio() bool { return len(tn.IconTre
 // ////////////////////////////////////////////////////////////////
 type CloudTreeNode struct {
 	abstractSquareTreeNode
-	vpcs []SquareTreeNodeInterface
+	vpcs                []SquareTreeNodeInterface
 	groupSubnetsSquares []SquareTreeNodeInterface
 }
 
@@ -113,8 +113,8 @@ func (tn *CloudTreeNode) children() ([]SquareTreeNodeInterface, []IconTreeNodeIn
 // ////////////////////////////////////////////////////////////////////////////////////////
 type VpcTreeNode struct {
 	abstractSquareTreeNode
-	zones               []SquareTreeNodeInterface
-	sgs                 []SquareTreeNodeInterface
+	zones []SquareTreeNodeInterface
+	sgs   []SquareTreeNodeInterface
 }
 
 func NewVpcTreeNode(parent *CloudTreeNode, name string) *VpcTreeNode {
@@ -280,8 +280,8 @@ type GroupSubnetsSquareTreeNode struct {
 func GroupedSubnetsSquare(groupedSubnets []SquareTreeNodeInterface) SquareTreeNodeInterface {
 	sameZone, sameVpc := true, true
 	zone := groupedSubnets[0].Parent().(*ZoneTreeNode)
-	vpc := groupedSubnets[0].Parent().Parent().(*VpcTreeNode)
-	cloud := groupedSubnets[0].Parent().Parent().Parent().(*CloudTreeNode)
+	vpc := zone.Parent().(*VpcTreeNode)
+	cloud := vpc.Parent().(*CloudTreeNode)
 	for _, subnet := range groupedSubnets {
 		if zone != subnet.Parent() {
 			sameZone = false

--- a/pkg/drawio/subnetsLayout.go
+++ b/pkg/drawio/subnetsLayout.go
@@ -101,16 +101,6 @@ func (group *groupDataS) isInnerGroup(subGroup *groupDataS) bool {
 	return true
 }
 
-func (group *groupDataS) getVpc() *VpcTreeNode {
-	if group.treeNode != nil {
-		return group.treeNode.Parent().(*VpcTreeNode)
-	}
-	for g := range group.splitFrom {
-		return g.getVpc()
-	}
-	return nil
-}
-
 func (group *groupDataS) reunion() {
 	for gr := range group.splitTo {
 		delete(gr.splitFrom, group)
@@ -720,7 +710,7 @@ func (ly *subnetsLayout) createNewGroupsTreeNodes() {
 			if len(subnets) == 1 {
 				group.treeNode = subnets[0]
 			} else {
-				group.treeNode = GroupedSubnetsSquare(group.getVpc(), subnets)
+				group.treeNode = GroupedSubnetsSquare(subnets)
 			}
 			ly.treeNodesToGroups[group.treeNode] = group
 		}

--- a/pkg/drawio/subnetsLayout.go
+++ b/pkg/drawio/subnetsLayout.go
@@ -1,7 +1,7 @@
 package drawio
 
 import (
-	"maps"
+		"maps"
 	"sort"
 
 	"github.com/np-guard/vpc-network-config-analyzer/pkg/common"
@@ -506,7 +506,7 @@ func (ly *subnetsLayout) setZonesCol(zoneOrders [][]TreeNodeInterface) {
 		for _, order := range vpcOrders {
 			for _, z := range order {
 				ly.zonesCol[z] = i
-				i++
+								i++
 			}
 		}
 	}
@@ -528,6 +528,14 @@ func (ly *subnetsLayout) calcZonePairScores() map[TreeNodeInterface]map[TreeNode
 					}
 					zonesScores[miniGroup1.zone][miniGroup2.zone] += 1
 				}
+			}
+		}
+	}
+	// for a pair of zones of the same vpc, we gives higher score then pair from different zone:
+	for z1, friendsScore := range zonesScores {
+		for z2 := range friendsScore {
+			if z1.Parent() == z2.Parent() {
+				zonesScores[z1][z2] += len(ly.miniGroups)*len(ly.miniGroups)
 			}
 		}
 	}

--- a/pkg/drawio/subnetsLayout.go
+++ b/pkg/drawio/subnetsLayout.go
@@ -1,7 +1,7 @@
 package drawio
 
 import (
-		"maps"
+	"maps"
 	"sort"
 
 	"github.com/np-guard/vpc-network-config-analyzer/pkg/common"
@@ -506,7 +506,7 @@ func (ly *subnetsLayout) setZonesCol(zoneOrders [][]TreeNodeInterface) {
 		for _, order := range vpcOrders {
 			for _, z := range order {
 				ly.zonesCol[z] = i
-								i++
+				i++
 			}
 		}
 	}
@@ -535,7 +535,7 @@ func (ly *subnetsLayout) calcZonePairScores() map[TreeNodeInterface]map[TreeNode
 	for z1, friendsScore := range zonesScores {
 		for z2 := range friendsScore {
 			if z1.Parent() == z2.Parent() {
-				zonesScores[z1][z2] += len(ly.miniGroups)*len(ly.miniGroups)
+				zonesScores[z1][z2] += len(ly.miniGroups) * len(ly.miniGroups)
 			}
 		}
 	}

--- a/pkg/ibmvpc/analysis_output_test.go
+++ b/pkg/ibmvpc/analysis_output_test.go
@@ -145,27 +145,6 @@ func (tt *vpcGeneralTest) initTest() {
 }
 
 var tests = []*vpcGeneralTest{
-// 	{
-// 	name:     "tgw_basic_example",
-// 	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllSubnets},
-// 	format:   vpcmodel.DRAWIO,
-// 	grouping: true,
-// },
-// {
-// 	name:     "tgw_larger_example",
-// 	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllEndpoints, vpcmodel.AllSubnets},
-// 	format:   vpcmodel.DRAWIO,
-// 	grouping: true,
-// },
-{
-	name:     "tgw_larger_example",
-	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllSubnets},
-	format:   vpcmodel.DRAWIO,
-	grouping: true,
-},
-}
-
-var tests2 = []*vpcGeneralTest{
 	{
 		name:     "acl_testing5",
 		useCases: []vpcmodel.OutputUseCase{vpcmodel.AllSubnets},

--- a/pkg/ibmvpc/analysis_output_test.go
+++ b/pkg/ibmvpc/analysis_output_test.go
@@ -146,6 +146,21 @@ func (tt *vpcGeneralTest) initTest() {
 
 var tests = []*vpcGeneralTest{
 	{
+	name:     "tgw_basic_example",
+	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllSubnets},
+	format:   vpcmodel.DRAWIO,
+	grouping: true,
+},
+{
+	name:     "tgw_larger_example",
+	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllEndpoints, vpcmodel.AllSubnets},
+	format:   vpcmodel.DRAWIO,
+	grouping: true,
+},
+}
+
+var tests2 = []*vpcGeneralTest{
+	{
 		name:     "acl_testing5",
 		useCases: []vpcmodel.OutputUseCase{vpcmodel.AllSubnets},
 		format:   vpcmodel.MD,

--- a/pkg/ibmvpc/analysis_output_test.go
+++ b/pkg/ibmvpc/analysis_output_test.go
@@ -145,15 +145,21 @@ func (tt *vpcGeneralTest) initTest() {
 }
 
 var tests = []*vpcGeneralTest{
-	{
-	name:     "tgw_basic_example",
-	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllSubnets},
-	format:   vpcmodel.DRAWIO,
-	grouping: true,
-},
+// 	{
+// 	name:     "tgw_basic_example",
+// 	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllSubnets},
+// 	format:   vpcmodel.DRAWIO,
+// 	grouping: true,
+// },
+// {
+// 	name:     "tgw_larger_example",
+// 	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllEndpoints, vpcmodel.AllSubnets},
+// 	format:   vpcmodel.DRAWIO,
+// 	grouping: true,
+// },
 {
 	name:     "tgw_larger_example",
-	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllEndpoints, vpcmodel.AllSubnets},
+	useCases: []vpcmodel.OutputUseCase{vpcmodel.AllSubnets},
 	format:   vpcmodel.DRAWIO,
 	grouping: true,
 },

--- a/pkg/vpcmodel/drawioGenerator.go
+++ b/pkg/vpcmodel/drawioGenerator.go
@@ -70,8 +70,7 @@ func (g *groupedEndpointsElems) GenerateDrawioTreeNode(gen *DrawioGenerator) dra
 		for i, node := range *g {
 			groupedSubnetsTNs[i] = gen.TreeNode(node).(drawio.SquareTreeNodeInterface)
 		}
-		vpcTn := groupedSubnetsTNs[0].Parent().Parent().(*drawio.VpcTreeNode)
-		return drawio.GroupedSubnetsSquare(vpcTn, groupedSubnetsTNs)
+		return drawio.GroupedSubnetsSquare(groupedSubnetsTNs)
 	}
 	groupedIconsTNs := make([]drawio.IconTreeNodeInterface, len(*g))
 	for i, node := range *g {


### PR DESCRIPTION
its not a big change.
I found out that there are groups with subnets from different vpcs, so I did two things:
1. moving GroupSubnetsSquareTreeNode to be the child of CloudTreeNode
2. in subnet layouting, in zone indexing, I gave pairs of zones from the same vpc a bigger score 