### PR TITLE
Adding setup-go action for CodeQL to work with Go 1.21

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,6 +43,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+      with:
+        go-version-file: ./go.mod
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@b7bf0a3ed3ecfa44160715d7c442788f65f0f923


### PR DESCRIPTION
CodeQL defaulted to Go 1.20, and so could not process Go 1.21 packages. This resulted in an error in the Security tab.
Adding a `setup-go` action before CodeQL starts seems to solve this issue.