### PR TITLE
issue #397: add InternalNode interface + use ExternalNode where possible

### DIFF
--- a/pkg/ibmvpc/connectivityAnalysis_test.go
+++ b/pkg/ibmvpc/connectivityAnalysis_test.go
@@ -334,10 +334,9 @@ func icmpConn() *common.ConnectionSet {
 
 func addInterfaceNode(config *vpcmodel.VPCConfig, name, address, vsiName, subnetName string) {
 	intfNode := &NetworkInterface{
-		VPCResource: vpcmodel.VPCResource{ResourceName: name, ResourceUID: name, ResourceType: ResourceTypeNetworkInterface},
-		address:     address,
-		vsi:         vsiName,
-		ipblock:     newIPBlockFromCIDROrAddressWithoutValidation(address),
+		VPCResource:  vpcmodel.VPCResource{ResourceName: name, ResourceUID: name, ResourceType: ResourceTypeNetworkInterface},
+		InternalNode: vpcmodel.InternalNode{AddressStr: address, IPBlockObj: newIPBlockFromCIDROrAddressWithoutValidation(address)},
+		vsi:          vsiName,
 	}
 	// add references between subnet to interface (both directions)
 	for _, subnet := range config.NodeSets {

--- a/pkg/ibmvpc/examples/out/analysis_out/acl_testing3_all_vpcs_.json
+++ b/pkg/ibmvpc/examples/out/analysis_out/acl_testing3_all_vpcs_.json
@@ -10,7 +10,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -27,7 +28,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -44,7 +46,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -61,7 +64,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -78,7 +82,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -95,7 +100,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -112,7 +118,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -129,7 +136,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -146,7 +154,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -163,7 +172,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -180,7 +190,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -197,7 +208,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -214,7 +226,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -231,7 +244,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -248,7 +262,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -265,7 +280,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -282,7 +298,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -299,7 +316,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -316,7 +334,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -333,7 +352,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -350,7 +370,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -367,7 +388,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -384,7 +406,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -401,7 +424,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -418,7 +442,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -435,7 +460,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -452,7 +478,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -469,7 +496,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -486,7 +514,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -503,7 +532,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -520,7 +550,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -537,7 +568,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -554,7 +586,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -571,7 +604,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -588,7 +622,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -605,7 +640,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -622,7 +658,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -639,7 +676,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -656,7 +694,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -673,7 +712,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -690,7 +730,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -707,7 +748,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -724,7 +766,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -741,7 +784,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -758,7 +802,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -775,7 +820,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -792,7 +838,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -809,7 +856,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -826,7 +874,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -843,7 +892,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -860,7 +910,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -877,7 +928,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -894,7 +946,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -911,7 +964,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -928,7 +982,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -945,7 +1000,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -962,7 +1018,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -979,7 +1036,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -996,7 +1054,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1013,7 +1072,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1030,7 +1090,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1047,7 +1108,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1064,7 +1126,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1081,7 +1144,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1098,7 +1162,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1115,7 +1180,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1132,7 +1198,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1149,7 +1216,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1166,7 +1234,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1183,7 +1252,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1200,7 +1270,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1217,7 +1288,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1234,7 +1306,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1251,7 +1324,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1268,7 +1342,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1285,7 +1360,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1302,7 +1378,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1319,7 +1396,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1336,7 +1414,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1353,7 +1432,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1370,7 +1450,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1387,7 +1468,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1404,7 +1486,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1421,7 +1504,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1438,7 +1522,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1455,7 +1540,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1472,7 +1558,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1489,7 +1576,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1506,7 +1594,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1523,7 +1612,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1540,7 +1630,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1557,7 +1648,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1574,7 +1666,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1591,7 +1684,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1608,7 +1702,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1625,7 +1720,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1642,7 +1738,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1659,7 +1756,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1676,7 +1774,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1693,7 +1792,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1710,7 +1810,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1727,7 +1828,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1744,7 +1846,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1761,7 +1864,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1778,7 +1882,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1795,7 +1900,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1812,7 +1918,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1829,7 +1936,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1846,7 +1954,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1863,7 +1972,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1880,7 +1990,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1897,7 +2008,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1914,7 +2026,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1931,7 +2044,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1948,7 +2062,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1965,7 +2080,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1982,7 +2098,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -1999,7 +2116,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2016,7 +2134,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2033,7 +2152,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2050,7 +2170,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2067,7 +2188,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2084,7 +2206,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2101,7 +2224,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2118,7 +2242,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2135,7 +2260,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2152,7 +2278,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2169,7 +2296,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2186,7 +2314,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2203,7 +2332,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2220,7 +2350,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2237,7 +2368,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2254,7 +2386,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2271,7 +2404,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2288,7 +2422,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2305,7 +2440,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2322,7 +2458,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2339,7 +2476,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2356,7 +2494,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2373,7 +2512,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2390,7 +2530,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2407,7 +2548,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2424,7 +2566,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2441,7 +2584,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2458,7 +2602,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2475,7 +2620,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2492,7 +2638,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2509,7 +2656,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2526,7 +2674,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2543,7 +2692,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2560,7 +2710,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2577,7 +2728,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2594,7 +2746,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2611,7 +2764,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2628,7 +2782,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2645,7 +2800,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2662,7 +2818,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2679,7 +2836,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2696,7 +2854,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2713,7 +2872,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2726,13 +2886,15 @@
                     "ResourceName": "vpe-for-etcd-db-ky",
                     "ResourceUID": "id:5",
                     "ResourceType": "ReservedIP",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.7"
                 },
                 "dst": {
                     "ResourceName": "cycling-juvenile-traipse-paramount",
                     "ResourceUID": "id:42",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.10.4"
                 },
                 "conn": [
                     {
@@ -2753,13 +2915,15 @@
                     "ResourceName": "vpe-for-etcd-db-ky",
                     "ResourceUID": "id:5",
                     "ResourceType": "ReservedIP",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.7"
                 },
                 "dst": {
                     "ResourceName": "data-washstand-blot-scrambler",
                     "ResourceUID": "id:71",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.5"
                 },
                 "conn": [
                     {
@@ -2772,13 +2936,15 @@
                     "ResourceName": "vpe-for-etcd-db-ky",
                     "ResourceUID": "id:5",
                     "ResourceType": "ReservedIP",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.7"
                 },
                 "dst": {
                     "ResourceName": "filterable-steersman-collar-whoops",
                     "ResourceUID": "id:100",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.6"
                 },
                 "conn": [
                     {
@@ -2791,13 +2957,15 @@
                     "ResourceName": "vpe-for-etcd-db-ky",
                     "ResourceUID": "id:5",
                     "ResourceType": "ReservedIP",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.7"
                 },
                 "dst": {
                     "ResourceName": "contest-dance-divided-brilliant",
                     "ResourceUID": "id:87",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.4"
                 },
                 "conn": [
                     {
@@ -2810,7 +2978,8 @@
                     "ResourceName": "cycling-juvenile-traipse-paramount",
                     "ResourceUID": "id:42",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.10.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2827,13 +2996,15 @@
                     "ResourceName": "cycling-juvenile-traipse-paramount",
                     "ResourceUID": "id:42",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.10.4"
                 },
                 "dst": {
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "conn": [
                     {
@@ -2849,7 +3020,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2866,7 +3038,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2883,7 +3056,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2900,7 +3074,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2917,7 +3092,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2934,7 +3110,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2951,7 +3128,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2968,7 +3146,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2985,7 +3164,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3002,7 +3182,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3019,7 +3200,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3036,7 +3218,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3053,7 +3236,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3070,7 +3254,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3087,7 +3272,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3104,7 +3290,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3121,7 +3308,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3138,7 +3326,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3155,7 +3344,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3172,7 +3362,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3189,7 +3380,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3206,7 +3398,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3223,7 +3416,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3240,7 +3434,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3257,7 +3452,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3274,7 +3470,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3291,7 +3488,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3308,7 +3506,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3325,7 +3524,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3342,7 +3542,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3359,7 +3560,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3376,7 +3578,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3393,7 +3596,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3410,7 +3614,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3427,7 +3632,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3444,7 +3650,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3461,7 +3668,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3478,7 +3686,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3495,7 +3704,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3512,7 +3722,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3529,7 +3740,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3546,7 +3758,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3563,7 +3776,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3580,7 +3794,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3597,7 +3812,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3614,7 +3830,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3631,7 +3848,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3648,7 +3866,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3665,7 +3884,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3682,7 +3902,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3699,7 +3920,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3716,7 +3938,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3733,7 +3956,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3750,7 +3974,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3767,7 +3992,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3784,7 +4010,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3801,7 +4028,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3818,7 +4046,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3835,7 +4064,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3852,7 +4082,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3869,7 +4100,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3886,7 +4118,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3903,7 +4136,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3920,7 +4154,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3937,7 +4172,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3954,7 +4190,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3971,7 +4208,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3988,7 +4226,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4005,7 +4244,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4022,7 +4262,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4039,7 +4280,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4056,7 +4298,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4073,7 +4316,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4090,7 +4334,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4107,7 +4352,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4124,7 +4370,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4141,7 +4388,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4158,7 +4406,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4175,7 +4424,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4192,7 +4442,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4209,7 +4460,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4226,7 +4478,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4243,7 +4496,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4260,7 +4514,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4277,7 +4532,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4294,7 +4550,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4311,7 +4568,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4328,7 +4586,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4345,7 +4604,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4362,7 +4622,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4379,7 +4640,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4396,7 +4658,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4413,7 +4676,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4430,7 +4694,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4447,7 +4712,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4464,7 +4730,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4481,7 +4748,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4498,7 +4766,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4515,7 +4784,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4532,7 +4802,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4549,7 +4820,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4566,7 +4838,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4583,7 +4856,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4600,7 +4874,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4617,7 +4892,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4634,7 +4910,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4651,7 +4928,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4668,7 +4946,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4685,7 +4964,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4702,7 +4982,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4719,7 +5000,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4736,7 +5018,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4753,7 +5036,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4770,7 +5054,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4787,7 +5072,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4804,7 +5090,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4821,7 +5108,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4838,7 +5126,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4855,7 +5144,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4872,7 +5162,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4889,7 +5180,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4906,7 +5198,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4923,7 +5216,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4940,7 +5234,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4957,7 +5252,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4974,7 +5270,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4991,7 +5288,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5008,7 +5306,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5025,7 +5324,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5042,7 +5342,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5059,7 +5360,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5076,7 +5378,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5093,7 +5396,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5110,7 +5414,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5127,7 +5432,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5144,7 +5450,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5161,7 +5468,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5178,7 +5486,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5195,7 +5504,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5212,7 +5522,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5229,7 +5540,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5246,7 +5558,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5263,7 +5576,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5280,7 +5594,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5297,7 +5612,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5314,7 +5630,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5331,7 +5648,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5348,7 +5666,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5365,7 +5684,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5382,7 +5702,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5399,7 +5720,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5416,7 +5738,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5433,7 +5756,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5450,7 +5774,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5467,7 +5792,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5484,7 +5810,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5501,7 +5828,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5518,7 +5846,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5535,7 +5864,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5552,7 +5882,8 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5569,13 +5900,15 @@
                     "ResourceName": "yarn-canary-guileless-deftly",
                     "ResourceUID": "id:19",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.20.4"
                 },
                 "dst": {
                     "ResourceName": "cycling-juvenile-traipse-paramount",
                     "ResourceUID": "id:42",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.10.4"
                 },
                 "conn": [
                     {
@@ -5588,13 +5921,15 @@
                     "ResourceName": "data-washstand-blot-scrambler",
                     "ResourceUID": "id:71",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.5"
                 },
                 "dst": {
                     "ResourceName": "vpe-for-etcd-db-ky",
                     "ResourceUID": "id:5",
                     "ResourceType": "ReservedIP",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.7"
                 },
                 "conn": [
                     {
@@ -5607,13 +5942,15 @@
                     "ResourceName": "data-washstand-blot-scrambler",
                     "ResourceUID": "id:71",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.5"
                 },
                 "dst": {
                     "ResourceName": "cycling-juvenile-traipse-paramount",
                     "ResourceUID": "id:42",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.10.4"
                 },
                 "conn": [
                     {
@@ -5634,13 +5971,15 @@
                     "ResourceName": "data-washstand-blot-scrambler",
                     "ResourceUID": "id:71",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.5"
                 },
                 "dst": {
                     "ResourceName": "filterable-steersman-collar-whoops",
                     "ResourceUID": "id:100",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.6"
                 },
                 "conn": [
                     {
@@ -5653,13 +5992,15 @@
                     "ResourceName": "data-washstand-blot-scrambler",
                     "ResourceUID": "id:71",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.5"
                 },
                 "dst": {
                     "ResourceName": "contest-dance-divided-brilliant",
                     "ResourceUID": "id:87",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.4"
                 },
                 "conn": [
                     {
@@ -5672,13 +6013,15 @@
                     "ResourceName": "filterable-steersman-collar-whoops",
                     "ResourceUID": "id:100",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.6"
                 },
                 "dst": {
                     "ResourceName": "vpe-for-etcd-db-ky",
                     "ResourceUID": "id:5",
                     "ResourceType": "ReservedIP",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.7"
                 },
                 "conn": [
                     {
@@ -5691,13 +6034,15 @@
                     "ResourceName": "filterable-steersman-collar-whoops",
                     "ResourceUID": "id:100",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.6"
                 },
                 "dst": {
                     "ResourceName": "cycling-juvenile-traipse-paramount",
                     "ResourceUID": "id:42",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.10.4"
                 },
                 "conn": [
                     {
@@ -5718,13 +6063,15 @@
                     "ResourceName": "filterable-steersman-collar-whoops",
                     "ResourceUID": "id:100",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.6"
                 },
                 "dst": {
                     "ResourceName": "data-washstand-blot-scrambler",
                     "ResourceUID": "id:71",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.5"
                 },
                 "conn": [
                     {
@@ -5737,13 +6084,15 @@
                     "ResourceName": "filterable-steersman-collar-whoops",
                     "ResourceUID": "id:100",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.6"
                 },
                 "dst": {
                     "ResourceName": "contest-dance-divided-brilliant",
                     "ResourceUID": "id:87",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.4"
                 },
                 "conn": [
                     {
@@ -5756,13 +6105,15 @@
                     "ResourceName": "contest-dance-divided-brilliant",
                     "ResourceUID": "id:87",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.4"
                 },
                 "dst": {
                     "ResourceName": "vpe-for-etcd-db-ky",
                     "ResourceUID": "id:5",
                     "ResourceType": "ReservedIP",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.7"
                 },
                 "conn": [
                     {
@@ -5775,13 +6126,15 @@
                     "ResourceName": "contest-dance-divided-brilliant",
                     "ResourceUID": "id:87",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.4"
                 },
                 "dst": {
                     "ResourceName": "cycling-juvenile-traipse-paramount",
                     "ResourceUID": "id:42",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.10.4"
                 },
                 "conn": [
                     {
@@ -5802,13 +6155,15 @@
                     "ResourceName": "contest-dance-divided-brilliant",
                     "ResourceUID": "id:87",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.4"
                 },
                 "dst": {
                     "ResourceName": "data-washstand-blot-scrambler",
                     "ResourceUID": "id:71",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.5"
                 },
                 "conn": [
                     {
@@ -5821,13 +6176,15 @@
                     "ResourceName": "contest-dance-divided-brilliant",
                     "ResourceUID": "id:87",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.4"
                 },
                 "dst": {
                     "ResourceName": "filterable-steersman-collar-whoops",
                     "ResourceUID": "id:100",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.30.6"
                 },
                 "conn": [
                     {

--- a/pkg/ibmvpc/examples/out/analysis_out/demo_with_instances_all_vpcs_.json
+++ b/pkg/ibmvpc/examples/out/analysis_out/demo_with_instances_all_vpcs_.json
@@ -6,7 +6,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -23,7 +24,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -40,7 +42,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -57,7 +60,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -74,7 +78,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -91,7 +96,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -108,7 +114,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -125,7 +132,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -142,7 +150,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -159,7 +168,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -176,7 +186,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -193,7 +204,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -210,7 +222,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -227,7 +240,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -244,7 +258,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -261,7 +276,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -278,7 +294,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -295,7 +312,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -312,7 +330,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -329,7 +348,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -346,7 +366,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -363,7 +384,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -380,7 +402,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -397,7 +420,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -414,7 +438,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -431,7 +456,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -448,7 +474,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -465,7 +492,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -482,7 +510,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -499,7 +528,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -516,7 +546,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -533,7 +564,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -550,7 +582,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -567,7 +600,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -584,7 +618,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -601,7 +636,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -618,7 +654,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -635,7 +672,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -652,7 +690,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -669,7 +708,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -686,7 +726,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -703,7 +744,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -720,7 +762,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -737,7 +780,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -754,7 +798,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -771,7 +816,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -788,7 +834,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -805,7 +852,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -822,7 +870,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -839,7 +888,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -856,7 +906,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -873,7 +924,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -890,7 +942,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -907,7 +960,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -924,7 +978,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -941,7 +996,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -958,7 +1014,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -975,7 +1032,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -992,7 +1050,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1009,7 +1068,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1026,7 +1086,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1043,7 +1104,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1060,7 +1122,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1077,7 +1140,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1094,7 +1158,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1111,7 +1176,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1128,7 +1194,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1145,7 +1212,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1162,7 +1230,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1179,7 +1248,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1196,7 +1266,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1213,7 +1284,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1230,7 +1302,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1247,7 +1320,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1264,7 +1338,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1281,7 +1356,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1298,7 +1374,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1315,7 +1392,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1332,7 +1410,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1349,7 +1428,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1366,7 +1446,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1383,7 +1464,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1400,7 +1482,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1417,7 +1500,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1434,7 +1518,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1451,7 +1536,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1468,7 +1554,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1485,7 +1572,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1502,7 +1590,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1519,7 +1608,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1536,7 +1626,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1553,7 +1644,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1570,7 +1662,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1587,7 +1680,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1604,7 +1698,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1621,7 +1716,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1638,7 +1734,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1655,7 +1752,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1672,7 +1770,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1689,7 +1788,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1706,7 +1806,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1723,7 +1824,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1740,7 +1842,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1757,7 +1860,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1774,7 +1878,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1791,7 +1896,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1808,7 +1914,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1825,7 +1932,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1842,7 +1950,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1859,7 +1968,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1876,7 +1986,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1893,7 +2004,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1910,7 +2022,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1927,7 +2040,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1944,7 +2058,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1961,7 +2076,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1978,7 +2094,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1995,7 +2112,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2012,7 +2130,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2029,7 +2148,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2046,7 +2166,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2063,7 +2184,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2080,7 +2202,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2097,7 +2220,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2114,7 +2238,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2131,7 +2256,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2148,7 +2274,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2165,7 +2292,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2182,7 +2310,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2199,7 +2328,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2216,7 +2346,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2233,7 +2364,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2250,7 +2382,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2267,7 +2400,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2284,7 +2418,8 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2301,13 +2436,15 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "conn": [
                     {
@@ -2320,13 +2457,15 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "conn": [
                     {
@@ -2339,13 +2478,15 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "conn": [
                     {
@@ -2360,13 +2501,15 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "conn": [
                     {
@@ -2381,13 +2524,15 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "conn": [
                     {
@@ -2402,13 +2547,15 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "conn": [
                     {
@@ -2421,13 +2568,15 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "conn": [
                     {
@@ -2440,13 +2589,15 @@
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "dst": {
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "conn": [
                     {
@@ -2459,7 +2610,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2476,7 +2628,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2493,7 +2646,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2510,7 +2664,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2527,7 +2682,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2544,7 +2700,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2561,7 +2718,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2578,7 +2736,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2595,7 +2754,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2612,7 +2772,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2629,7 +2790,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2646,7 +2808,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2663,7 +2826,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2680,7 +2844,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2697,7 +2862,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2714,7 +2880,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2731,7 +2898,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2748,7 +2916,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2765,7 +2934,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2782,7 +2952,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2799,7 +2970,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2816,7 +2988,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2833,7 +3006,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2850,7 +3024,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2867,7 +3042,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2884,7 +3060,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2901,7 +3078,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2918,7 +3096,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2935,7 +3114,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2952,7 +3132,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2969,7 +3150,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2986,7 +3168,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3003,7 +3186,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3020,7 +3204,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3037,7 +3222,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3054,7 +3240,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3071,7 +3258,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3088,7 +3276,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3105,7 +3294,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3122,7 +3312,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3139,7 +3330,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3156,7 +3348,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3173,7 +3366,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3190,7 +3384,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3207,7 +3402,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3224,7 +3420,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3241,7 +3438,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3258,7 +3456,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3275,7 +3474,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3292,7 +3492,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3309,7 +3510,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3326,7 +3528,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3343,7 +3546,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3360,7 +3564,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3377,7 +3582,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3394,7 +3600,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3411,7 +3618,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3428,7 +3636,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3445,7 +3654,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3462,7 +3672,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3479,7 +3690,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3496,7 +3708,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3513,7 +3726,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3530,7 +3744,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3547,7 +3762,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3564,7 +3780,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3581,7 +3798,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3598,7 +3816,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3615,7 +3834,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3632,7 +3852,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3649,7 +3870,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3666,7 +3888,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3683,7 +3906,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3700,7 +3924,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3717,7 +3942,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3734,7 +3960,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3751,7 +3978,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3768,7 +3996,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3785,7 +4014,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3802,7 +4032,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3819,7 +4050,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3836,7 +4068,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3853,7 +4086,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3870,7 +4104,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3887,7 +4122,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3904,7 +4140,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3921,7 +4158,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3938,7 +4176,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3955,7 +4194,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3972,7 +4212,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3989,7 +4230,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4006,7 +4248,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4023,7 +4266,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4040,7 +4284,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4057,7 +4302,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4074,7 +4320,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4091,7 +4338,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4108,7 +4356,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4125,7 +4374,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4142,7 +4392,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4159,7 +4410,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4176,7 +4428,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4193,7 +4446,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4210,7 +4464,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4227,7 +4482,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4244,7 +4500,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4261,7 +4518,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4278,7 +4536,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4295,7 +4554,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4312,7 +4572,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4329,7 +4590,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4346,7 +4608,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4363,7 +4626,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4380,7 +4644,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4397,7 +4662,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4414,7 +4680,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4431,7 +4698,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4448,7 +4716,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4465,7 +4734,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4482,7 +4752,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4499,7 +4770,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4516,7 +4788,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4533,7 +4806,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4550,7 +4824,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4567,7 +4842,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4584,7 +4860,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4601,7 +4878,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4618,7 +4896,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4635,7 +4914,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4652,7 +4932,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4669,7 +4950,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4686,7 +4968,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4703,7 +4986,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4720,7 +5004,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4737,7 +5022,8 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4754,13 +5040,15 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "conn": [
                     {
@@ -4773,13 +5061,15 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "conn": [
                     {
@@ -4792,13 +5082,15 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "conn": [
                     {
@@ -4813,13 +5105,15 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "conn": [
                     {
@@ -4834,13 +5128,15 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "conn": [
                     {
@@ -4855,13 +5151,15 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "conn": [
                     {
@@ -4874,13 +5172,15 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "conn": [
                     {
@@ -4893,13 +5193,15 @@
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "dst": {
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "conn": [
                     {
@@ -4912,7 +5214,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4929,7 +5232,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4946,7 +5250,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4963,7 +5268,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4980,7 +5286,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4997,7 +5304,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5014,7 +5322,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5031,7 +5340,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5048,7 +5358,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5065,7 +5376,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5082,7 +5394,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5099,7 +5412,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5116,7 +5430,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5133,7 +5448,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5150,7 +5466,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5167,7 +5484,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5184,7 +5502,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5201,7 +5520,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5218,7 +5538,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5235,7 +5556,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5252,7 +5574,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5269,7 +5592,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5286,7 +5610,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5303,7 +5628,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5320,7 +5646,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5337,7 +5664,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5354,7 +5682,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5371,7 +5700,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5388,7 +5718,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5405,7 +5736,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5422,7 +5754,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5439,7 +5772,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5456,7 +5790,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5473,7 +5808,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5490,7 +5826,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5507,7 +5844,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5524,7 +5862,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5541,7 +5880,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5558,7 +5898,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5575,7 +5916,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5592,7 +5934,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5609,7 +5952,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5626,7 +5970,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5643,7 +5988,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5660,7 +6006,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5677,7 +6024,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5694,7 +6042,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5711,7 +6060,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5728,7 +6078,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5745,7 +6096,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5762,7 +6114,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5779,7 +6132,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5796,7 +6150,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5813,7 +6168,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5830,7 +6186,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5847,7 +6204,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5864,7 +6222,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5881,7 +6240,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5898,7 +6258,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5915,7 +6276,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5932,7 +6294,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5949,7 +6312,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5966,7 +6330,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5983,7 +6348,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6000,7 +6366,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6017,7 +6384,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6034,7 +6402,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6051,7 +6420,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6068,7 +6438,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6085,7 +6456,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6102,7 +6474,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6119,7 +6492,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6136,7 +6510,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6153,7 +6528,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6170,7 +6546,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6187,7 +6564,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6204,7 +6582,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6221,7 +6600,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6238,7 +6618,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6255,7 +6636,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6272,7 +6654,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6289,7 +6672,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6306,7 +6690,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6323,7 +6708,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6340,7 +6726,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6357,7 +6744,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6374,7 +6762,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6391,7 +6780,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6408,7 +6798,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6425,7 +6816,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6442,7 +6834,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6459,7 +6852,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6476,7 +6870,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6493,7 +6888,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6510,7 +6906,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6527,7 +6924,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6544,7 +6942,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6561,7 +6960,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6578,7 +6978,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6595,7 +6996,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6612,7 +7014,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6629,7 +7032,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6646,7 +7050,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6663,7 +7068,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6680,7 +7086,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6697,7 +7104,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6714,7 +7122,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6731,7 +7140,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6748,7 +7158,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6765,7 +7176,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6782,7 +7194,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6799,7 +7212,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6816,7 +7230,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6833,7 +7248,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6850,7 +7266,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6867,7 +7284,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6884,7 +7302,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6901,7 +7320,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6918,7 +7338,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6935,7 +7356,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6952,7 +7374,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6969,7 +7392,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -6986,7 +7410,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7003,7 +7428,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7020,7 +7446,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7037,7 +7464,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7054,7 +7482,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7071,7 +7500,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7088,7 +7518,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7105,7 +7536,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7122,7 +7554,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7139,7 +7572,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7156,7 +7590,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7173,7 +7608,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7190,7 +7626,8 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -7207,13 +7644,15 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "conn": [
                     {
@@ -7226,13 +7665,15 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "conn": [
                     {
@@ -7245,13 +7686,15 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "conn": [
                     {
@@ -7266,13 +7709,15 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "conn": [
                     {
@@ -7287,13 +7732,15 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "conn": [
                     {
@@ -7308,13 +7755,15 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "conn": [
                     {
@@ -7327,13 +7776,15 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "conn": [
                     {
@@ -7346,13 +7797,15 @@
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "dst": {
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "conn": [
                     {
@@ -7365,13 +7818,15 @@
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "dst": {
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "conn": [
                     {
@@ -7386,13 +7841,15 @@
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "dst": {
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "conn": [
                     {
@@ -7407,13 +7864,15 @@
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "dst": {
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "conn": [
                     {
@@ -7428,13 +7887,15 @@
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "dst": {
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "conn": [
                     {
@@ -7451,13 +7912,15 @@
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "dst": {
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "conn": [
                     {
@@ -7474,13 +7937,15 @@
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "dst": {
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "conn": [
                     {
@@ -7495,13 +7960,15 @@
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "dst": {
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "conn": [
                     {
@@ -7516,13 +7983,15 @@
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "dst": {
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "conn": [
                     {
@@ -7537,13 +8006,15 @@
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "dst": {
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "conn": [
                     {
@@ -7558,13 +8029,15 @@
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "dst": {
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "conn": [
                     {
@@ -7579,13 +8052,15 @@
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "dst": {
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "conn": [
                     {
@@ -7600,13 +8075,15 @@
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "dst": {
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "conn": [
                     {
@@ -7623,13 +8100,15 @@
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "dst": {
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "conn": [
                     {
@@ -7646,13 +8125,15 @@
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "dst": {
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "conn": [
                     {
@@ -7667,13 +8148,15 @@
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "dst": {
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "conn": [
                     {
@@ -7688,13 +8171,15 @@
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "dst": {
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "conn": [
                     {
@@ -7709,13 +8194,15 @@
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "dst": {
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "conn": [
                     {
@@ -7730,13 +8217,15 @@
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "dst": {
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "conn": [
                     {
@@ -7751,13 +8240,15 @@
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "dst": {
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "conn": [
                     {
@@ -7772,13 +8263,15 @@
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "dst": {
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "conn": [
                     {
@@ -7795,13 +8288,15 @@
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "dst": {
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "conn": [
                     {
@@ -7818,13 +8313,15 @@
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "dst": {
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "conn": [
                     {
@@ -7839,13 +8336,15 @@
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "dst": {
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "conn": [
                     {
@@ -7860,13 +8359,15 @@
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "dst": {
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "conn": [
                     {
@@ -7881,13 +8382,15 @@
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "dst": {
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "conn": [
                     {
@@ -7900,13 +8403,15 @@
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "dst": {
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "conn": [
                     {
@@ -7919,13 +8424,15 @@
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "dst": {
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "conn": [
                     {
@@ -7938,13 +8445,15 @@
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "dst": {
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "conn": [
                     {
@@ -7959,13 +8468,15 @@
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "dst": {
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "conn": [
                     {
@@ -7980,13 +8491,15 @@
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "dst": {
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "conn": [
                     {
@@ -8001,13 +8514,15 @@
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "dst": {
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "conn": [
                     {
@@ -8020,13 +8535,15 @@
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "dst": {
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "conn": [
                     {
@@ -8039,13 +8556,15 @@
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "dst": {
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "conn": [
                     {
@@ -8058,13 +8577,15 @@
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "dst": {
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "conn": [
                     {
@@ -8077,13 +8598,15 @@
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "dst": {
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "conn": [
                     {
@@ -8096,13 +8619,15 @@
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "dst": {
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "conn": [
                     {
@@ -8117,13 +8642,15 @@
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "dst": {
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "conn": [
                     {
@@ -8138,13 +8665,15 @@
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "dst": {
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "conn": [
                     {
@@ -8159,13 +8688,15 @@
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "dst": {
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "conn": [
                     {
@@ -8178,13 +8709,15 @@
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "dst": {
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "conn": [
                     {
@@ -8197,13 +8730,15 @@
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "dst": {
                     "ResourceName": "unfairly-errant-reliably-geography",
                     "ResourceUID": "id:145",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.32.4"
                 },
                 "conn": [
                     {
@@ -8216,13 +8751,15 @@
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "dst": {
                     "ResourceName": "evoke-reprocess-detergent-unarmored",
                     "ResourceUID": "id:74",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.36.4"
                 },
                 "conn": [
                     {
@@ -8235,13 +8772,15 @@
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "dst": {
                     "ResourceName": "viewless-sprig-wreaths-immunize",
                     "ResourceUID": "id:34",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.40.4"
                 },
                 "conn": [
                     {
@@ -8254,13 +8793,15 @@
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "dst": {
                     "ResourceName": "dexterity-reneged-giggly-choice",
                     "ResourceUID": "id:54",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.0.4"
                 },
                 "conn": [
                     {
@@ -8275,13 +8816,15 @@
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "dst": {
                     "ResourceName": "underdog-breeches-porcupine-stainable",
                     "ResourceUID": "id:108",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.4.4"
                 },
                 "conn": [
                     {
@@ -8296,13 +8839,15 @@
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "dst": {
                     "ResourceName": "entreaty-evolution-baking-vista",
                     "ResourceUID": "id:179",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.8.4"
                 },
                 "conn": [
                     {
@@ -8317,13 +8862,15 @@
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "dst": {
                     "ResourceName": "bullish-sprinkled-paradox-gravity",
                     "ResourceUID": "id:91",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "192.168.16.4"
                 },
                 "conn": [
                     {
@@ -8336,13 +8883,15 @@
                     "ResourceName": "keep-borough-prankster-racings",
                     "ResourceUID": "id:125",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-3"
+                    "Zone": "us-south-3",
+                    "AddressStr": "192.168.24.4"
                 },
                 "dst": {
                     "ResourceName": "wool-daisy-energize-repeated",
                     "ResourceUID": "id:162",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-2"
+                    "Zone": "us-south-2",
+                    "AddressStr": "192.168.20.4"
                 },
                 "conn": [
                     {

--- a/pkg/ibmvpc/examples/out/analysis_out/experiments_env_all_vpcs_.json
+++ b/pkg/ibmvpc/examples/out/analysis_out/experiments_env_all_vpcs_.json
@@ -10,7 +10,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -27,7 +28,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -44,7 +46,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -61,7 +64,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -78,7 +82,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -95,7 +100,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -112,7 +118,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -129,7 +136,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -146,7 +154,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -163,7 +172,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -180,7 +190,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -197,7 +208,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -214,7 +226,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -231,7 +244,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -248,7 +262,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -265,7 +280,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -282,7 +298,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -299,7 +316,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -316,7 +334,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -333,7 +352,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -350,7 +370,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -367,7 +388,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -384,7 +406,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -401,7 +424,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -418,7 +442,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -435,7 +460,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -452,7 +478,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -469,7 +496,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -486,7 +514,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -503,7 +532,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -520,7 +550,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -537,7 +568,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -554,7 +586,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -571,7 +604,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -588,7 +622,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -605,7 +640,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -622,7 +658,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -639,7 +676,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -656,7 +694,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -673,7 +712,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -690,7 +730,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -707,7 +748,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -724,7 +766,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -741,7 +784,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -758,7 +802,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -775,7 +820,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -792,7 +838,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -809,7 +856,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -826,7 +874,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -843,7 +892,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -860,7 +910,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -877,7 +928,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -894,7 +946,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -911,7 +964,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -928,7 +982,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -945,7 +1000,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -962,7 +1018,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -979,7 +1036,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -996,7 +1054,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1013,7 +1072,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1030,7 +1090,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1047,7 +1108,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1064,7 +1126,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1081,7 +1144,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1098,7 +1162,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1115,7 +1180,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1132,7 +1198,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1149,7 +1216,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1166,7 +1234,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1183,7 +1252,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1200,7 +1270,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1217,7 +1288,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1234,7 +1306,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1251,7 +1324,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1268,7 +1342,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1285,7 +1360,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1302,7 +1378,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1319,7 +1396,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1336,7 +1414,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1353,7 +1432,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1370,7 +1450,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1387,7 +1468,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1404,7 +1486,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1421,7 +1504,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1438,7 +1522,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1455,7 +1540,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1472,7 +1558,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1489,7 +1576,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1506,7 +1594,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1523,7 +1612,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1540,7 +1630,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1557,7 +1648,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1574,7 +1666,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1591,7 +1684,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1608,7 +1702,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1625,7 +1720,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1642,7 +1738,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1659,7 +1756,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1676,7 +1774,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1693,7 +1792,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1710,7 +1810,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1727,7 +1828,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1744,7 +1846,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1761,7 +1864,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1778,7 +1882,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1795,7 +1900,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1812,7 +1918,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1829,7 +1936,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1846,7 +1954,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1863,7 +1972,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1880,7 +1990,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1897,7 +2008,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1914,7 +2026,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1931,7 +2044,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1948,7 +2062,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1965,7 +2080,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -1978,7 +2094,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -1995,7 +2112,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2012,7 +2130,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2029,7 +2148,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2046,7 +2166,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2063,7 +2184,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2080,7 +2202,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2097,7 +2220,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2114,7 +2238,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2131,7 +2256,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2148,7 +2274,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2165,7 +2292,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2182,7 +2310,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2199,7 +2328,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2216,7 +2346,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2233,7 +2364,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2250,7 +2382,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2267,7 +2400,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2284,7 +2418,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2301,7 +2436,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2318,7 +2454,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2335,7 +2472,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2352,7 +2490,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2369,7 +2508,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2386,7 +2526,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2403,7 +2544,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2420,7 +2562,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2437,7 +2580,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2454,7 +2598,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2471,7 +2616,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2488,7 +2634,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2505,7 +2652,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2522,7 +2670,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2539,7 +2688,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2556,7 +2706,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2573,7 +2724,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2590,7 +2742,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2607,7 +2760,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2624,7 +2778,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2641,7 +2796,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2658,7 +2814,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2675,7 +2832,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2692,7 +2850,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2709,7 +2868,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2726,7 +2886,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2743,7 +2904,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2760,7 +2922,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2777,7 +2940,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2794,7 +2958,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2811,7 +2976,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2828,7 +2994,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2845,7 +3012,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2862,7 +3030,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2879,7 +3048,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2896,7 +3066,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2913,7 +3084,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2930,7 +3102,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2947,7 +3120,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2964,7 +3138,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2981,7 +3156,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -2998,7 +3174,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3015,7 +3192,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3032,7 +3210,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3049,7 +3228,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3066,7 +3246,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3083,7 +3264,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3100,7 +3282,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3117,7 +3300,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3134,7 +3318,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3151,7 +3336,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3168,7 +3354,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3185,7 +3372,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3202,7 +3390,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3219,7 +3408,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3236,7 +3426,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3253,7 +3444,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3270,7 +3462,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3287,7 +3480,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3304,7 +3498,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3321,7 +3516,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3338,7 +3534,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3355,7 +3552,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3372,7 +3570,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3389,7 +3588,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3406,7 +3606,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3423,7 +3624,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3440,7 +3642,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3457,7 +3660,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3474,7 +3678,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3491,7 +3696,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3508,7 +3714,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3525,7 +3732,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3542,7 +3750,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3559,7 +3768,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3576,7 +3786,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3593,7 +3804,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3610,7 +3822,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3627,7 +3840,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3644,7 +3858,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3661,7 +3876,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3678,7 +3894,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3695,7 +3912,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3712,7 +3930,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3729,7 +3948,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3746,7 +3966,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3763,7 +3984,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3780,7 +4002,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3797,7 +4020,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3814,7 +4038,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3831,7 +4056,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3848,7 +4074,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3865,7 +4092,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3882,7 +4110,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3899,7 +4128,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3916,7 +4146,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3933,7 +4164,8 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -3950,13 +4182,15 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceName": "swept-epidemic-list-prong",
                     "ResourceUID": "id:90",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.1.4"
                 },
                 "conn": [
                     {
@@ -3969,13 +4203,15 @@
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "dst": {
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -3988,13 +4224,15 @@
                     "ResourceName": "swept-epidemic-list-prong",
                     "ResourceUID": "id:90",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.1.4"
                 },
                 "dst": {
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "conn": [
                     {
@@ -4007,13 +4245,15 @@
                     "ResourceName": "swept-epidemic-list-prong",
                     "ResourceUID": "id:90",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.1.4"
                 },
                 "dst": {
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "conn": [
                     {
@@ -4026,7 +4266,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4043,7 +4284,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4060,7 +4302,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4077,7 +4320,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4094,7 +4338,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4111,7 +4356,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4128,7 +4374,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4145,7 +4392,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4162,7 +4410,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4179,7 +4428,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4196,7 +4446,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4213,7 +4464,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4230,7 +4482,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4247,7 +4500,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4264,7 +4518,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4281,7 +4536,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4298,7 +4554,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4315,7 +4572,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4332,7 +4590,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4349,7 +4608,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4366,7 +4626,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4383,7 +4644,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4400,7 +4662,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4417,7 +4680,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4434,7 +4698,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4451,7 +4716,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4468,7 +4734,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4485,7 +4752,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4502,7 +4770,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4519,7 +4788,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4536,7 +4806,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4553,7 +4824,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4570,7 +4842,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4587,7 +4860,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4604,7 +4878,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4621,7 +4896,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4638,7 +4914,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4655,7 +4932,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4672,7 +4950,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4689,7 +4968,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4706,7 +4986,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4723,7 +5004,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4740,7 +5022,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4757,7 +5040,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4774,7 +5058,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4791,7 +5076,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4808,7 +5094,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4825,7 +5112,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4842,7 +5130,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4859,7 +5148,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4876,7 +5166,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4893,7 +5184,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4910,7 +5202,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4927,7 +5220,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4944,7 +5238,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4961,7 +5256,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4978,7 +5274,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -4995,7 +5292,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5012,7 +5310,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5029,7 +5328,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5046,7 +5346,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5063,7 +5364,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5080,7 +5382,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5097,7 +5400,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5114,7 +5418,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5131,7 +5436,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5148,7 +5454,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5165,7 +5472,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5182,7 +5490,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5199,7 +5508,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5216,7 +5526,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5233,7 +5544,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5250,7 +5562,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5267,7 +5580,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5284,7 +5598,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5301,7 +5616,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5318,7 +5634,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5335,7 +5652,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5352,7 +5670,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5369,7 +5688,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5386,7 +5706,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5403,7 +5724,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5420,7 +5742,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5437,7 +5760,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5454,7 +5778,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5471,7 +5796,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5488,7 +5814,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5505,7 +5832,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5522,7 +5850,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5539,7 +5868,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5556,7 +5886,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5573,7 +5904,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5590,7 +5922,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5607,7 +5940,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5624,7 +5958,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5641,7 +5976,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5658,7 +5994,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5675,7 +6012,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5692,7 +6030,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5709,7 +6048,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5726,7 +6066,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5743,7 +6084,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5760,7 +6102,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5777,7 +6120,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5794,7 +6138,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5811,7 +6156,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5828,7 +6174,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5845,7 +6192,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5862,7 +6210,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5879,7 +6228,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5896,7 +6246,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5913,7 +6264,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5930,7 +6282,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5947,7 +6300,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5964,7 +6318,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5981,7 +6336,8 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceType": "Public Internet",
@@ -5998,13 +6354,15 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceName": "chivalry-donation-molehill-stopper",
                     "ResourceUID": "id:48",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.0.5"
                 },
                 "conn": [
                     {
@@ -6017,13 +6375,15 @@
                     "ResourceName": "headrest-deceptive-transport-custody",
                     "ResourceUID": "id:68",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.2.4"
                 },
                 "dst": {
                     "ResourceName": "swept-epidemic-list-prong",
                     "ResourceUID": "id:90",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.1.4"
                 },
                 "conn": [
                     {
@@ -6040,13 +6400,15 @@
                     "ResourceName": "tint-reviver-caregiver-shorthand",
                     "ResourceUID": "id:107",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.128.4"
                 },
                 "dst": {
                     "ResourceName": "tint-reviver-caregiver-shorthand-11",
                     "ResourceUID": "id:10711",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.128.5"
                 },
                 "conn": [
                     {
@@ -6059,13 +6421,15 @@
                     "ResourceName": "tint-reviver-caregiver-shorthand-11",
                     "ResourceUID": "id:10711",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.128.5"
                 },
                 "dst": {
                     "ResourceName": "tint-reviver-caregiver-shorthand",
                     "ResourceUID": "id:107",
                     "ResourceType": "NetworkInterface",
-                    "Zone": "us-south-1"
+                    "Zone": "us-south-1",
+                    "AddressStr": "10.240.128.4"
                 },
                 "conn": [
                     {

--- a/pkg/ibmvpc/vpc.go
+++ b/pkg/ibmvpc/vpc.go
@@ -39,55 +39,21 @@ func zoneFromVPCResource(r vpcmodel.VPCResourceIntf) (*Zone, error) {
 // ReservedIP implements vpcmodel.Node interface
 type ReservedIP struct {
 	vpcmodel.VPCResource
-	address string
-	ipblock *common.IPBlock
-	subnet  *Subnet
-	vpe     string
-}
-
-func (r *ReservedIP) CidrOrAddress() string {
-	return r.address
-}
-
-func (r *ReservedIP) IPBlock() *common.IPBlock {
-	return r.ipblock
-}
-
-func (r *ReservedIP) IsInternal() bool {
-	return true
-}
-
-func (r *ReservedIP) IsPublicInternet() bool {
-	return false
+	vpcmodel.InternalNode
+	subnet *Subnet
+	vpe    string
 }
 
 func (r *ReservedIP) Name() string {
-	return getNodeName(r.vpe, r.address)
+	return getNodeName(r.vpe, r.Address())
 }
 
 // NetworkInterface implements vpcmodel.Node interface
 type NetworkInterface struct {
 	vpcmodel.VPCResource
-	address string
-	vsi     string
-	subnet  *Subnet
-	ipblock *common.IPBlock
-}
-
-func (ni *NetworkInterface) CidrOrAddress() string {
-	return ni.address
-}
-
-func (ni *NetworkInterface) IPBlock() *common.IPBlock {
-	return ni.ipblock
-}
-
-func (ni *NetworkInterface) IsInternal() bool {
-	return true
-}
-
-func (ni *NetworkInterface) IsPublicInternet() bool {
-	return false
+	vpcmodel.InternalNode
+	vsi    string
+	subnet *Subnet
 }
 
 func (ni *NetworkInterface) VsiName() string {
@@ -95,31 +61,14 @@ func (ni *NetworkInterface) VsiName() string {
 }
 
 func (ni *NetworkInterface) Name() string {
-	return getNodeName(ni.vsi, ni.address)
+	return getNodeName(ni.vsi, ni.Address())
 }
 
 // IKSNode implements vpcmodel.Node interface
 type IKSNode struct {
 	vpcmodel.VPCResource
-	address string
-	ipblock *common.IPBlock
-	subnet  *Subnet
-}
-
-func (n *IKSNode) CidrOrAddress() string {
-	return n.address
-}
-
-func (n *IKSNode) IPBlock() *common.IPBlock {
-	return n.ipblock
-}
-
-func (n *IKSNode) IsInternal() bool {
-	return true
-}
-
-func (n *IKSNode) IsPublicInternet() bool {
-	return false
+	vpcmodel.InternalNode
+	subnet *Subnet
 }
 
 func (n *IKSNode) VsiName() string {
@@ -127,7 +76,7 @@ func (n *IKSNode) VsiName() string {
 }
 
 func (n *IKSNode) Name() string {
-	return getNodeName(n.ResourceName, n.address)
+	return getNodeName(n.ResourceName, n.Address())
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -605,6 +554,7 @@ func (sg *SecurityGroup) getMemberTargetStrAddress(src, dst vpcmodel.Node,
 	} else {
 		member, target = src, dst
 	}
+	// TODO: member is expected to be internal node (validate?) [could use member.(vpcmodel.InternalNodeIntf).Address()]
 	return member.CidrOrAddress(), target.IPBlock()
 }
 

--- a/pkg/vpcmodel/abstractVPC.go
+++ b/pkg/vpcmodel/abstractVPC.go
@@ -67,8 +67,7 @@ const (
 
 ///////////////////////////vpc resources////////////////////////////////////////////////////////////////////////////
 
-// Node is the basic endpoint element in the connectivity graph [ network interface , reserved ip, external cidrs]
-
+// Node is the basic endpoint element in the connectivity graph [ network interface , reserved ip, iks node, external cidrs]
 type Node interface {
 	VPCResourceIntf
 	// CidrOrAddress returns the string of the Node's IP-address (for internal node) or CIDR (for external node)
@@ -80,6 +79,45 @@ type Node interface {
 	// IsPublicInternet returns true if the node is external,
 	// currently nodes which are external but not public Internet are ignored
 	IsPublicInternet() bool
+}
+
+// InternalNodeIntf captures common properties for internal nodes: single IP address
+type InternalNodeIntf interface {
+	// an InternalNodeIntf has an exact one IP Address
+	Address() string
+	IPBlock() *common.IPBlock
+	SetIPBlockFromAddress() error
+}
+
+// InternalNode implements interface InternalNodeIntf
+type InternalNode struct {
+	AddressStr string
+	IPBlockObj *common.IPBlock `json:"-"`
+}
+
+func (n *InternalNode) Address() string {
+	return n.AddressStr
+}
+
+func (n *InternalNode) IPBlock() *common.IPBlock {
+	return n.IPBlockObj
+}
+
+func (n *InternalNode) SetIPBlockFromAddress() (err error) {
+	n.IPBlockObj, err = common.NewIPBlockFromIPAddress(n.AddressStr)
+	return err
+}
+
+func (n *InternalNode) CidrOrAddress() string {
+	return n.AddressStr
+}
+
+func (n *InternalNode) IsInternal() bool {
+	return true
+}
+
+func (n *InternalNode) IsPublicInternet() bool {
+	return false
 }
 
 // NodeSet is an element that may capture several nodes [vpc ,subnet, vsi, vpe]

--- a/pkg/vpcmodel/abstractVPC.go
+++ b/pkg/vpcmodel/abstractVPC.go
@@ -84,13 +84,11 @@ type Node interface {
 // InternalNodeIntf captures common properties for internal nodes: single IP address
 // Implemented by NetworkInterface, IKSNode, ReservedIP (embedding InternalNode)
 type InternalNodeIntf interface {
+	// Address returns the node's address
 	// an InternalNodeIntf has an exact one IP Address
 	Address() string
 	// IPBlock returns the IPBlock object representing the node's IP Address
 	IPBlock() *common.IPBlock
-	// SetIPBlockFromAddress sets the node's IPBlock object from its Address .
-	// Assumes its address is assigned with valid IPv4 string value.
-	SetIPBlockFromAddress() error
 }
 
 // InternalNode implements interface InternalNodeIntf
@@ -112,6 +110,8 @@ func (n *InternalNode) IPBlock() *common.IPBlock {
 	return n.IPBlockObj
 }
 
+// SetIPBlockFromAddress sets the node's IPBlockObj field from its AddressStr field.
+// Assumes its AddressStr field is assigned with valid IPv4 string value.
 func (n *InternalNode) SetIPBlockFromAddress() (err error) {
 	n.IPBlockObj, err = common.NewIPBlockFromIPAddress(n.AddressStr)
 	return err

--- a/pkg/vpcmodel/abstractVPC.go
+++ b/pkg/vpcmodel/abstractVPC.go
@@ -99,7 +99,7 @@ type InternalNode struct {
 	// `json:"-"` is to avoid having this field in the JSON output (nodes connectivity output in JSON format),
 	// since it is sufficient to have the AddressStr, and no need to represent IPBlockObj as another
 	// attribute in the JSON output.
-	IPBlockObj *common.IPBlock `json:"-"` // avoid having this field in the JSON output
+	IPBlockObj *common.IPBlock `json:"-"`
 }
 
 func (n *InternalNode) Address() string {

--- a/pkg/vpcmodel/abstractVPC.go
+++ b/pkg/vpcmodel/abstractVPC.go
@@ -86,13 +86,21 @@ type Node interface {
 type InternalNodeIntf interface {
 	// an InternalNodeIntf has an exact one IP Address
 	Address() string
+	// IPBlock returns the IPBlock object representing the node's IP Address
 	IPBlock() *common.IPBlock
+	// SetIPBlockFromAddress sets the node's IPBlock object from its Address .
+	// Assumes its address is assigned with valid IPv4 string value.
 	SetIPBlockFromAddress() error
 }
 
 // InternalNode implements interface InternalNodeIntf
 type InternalNode struct {
+	// AddressStr is an IPv4 string, as the node's IP Address
 	AddressStr string
+	// IPBlockObj is an IPBlock object of the node's address (created from AddressStr)
+	// `json:"-"` is to avoid having this field in the JSON output (nodes connectivity output in JSON format),
+	// since it is sufficient to have the AddressStr, and no need to represent IPBlockObj as another
+	// attribute in the JSON output.
 	IPBlockObj *common.IPBlock `json:"-"` // avoid having this field in the JSON output
 }
 

--- a/pkg/vpcmodel/abstractVPC.go
+++ b/pkg/vpcmodel/abstractVPC.go
@@ -28,7 +28,7 @@ type VPCResource struct {
 	ResourceType string
 	Zone         string
 	// the VPC to which this resource belongs to
-	VPCRef VPCResourceIntf `json:"-"`
+	VPCRef VPCResourceIntf `json:"-"` // avoid having this field in the JSON output
 }
 
 func (n *VPCResource) Name() string {
@@ -82,6 +82,7 @@ type Node interface {
 }
 
 // InternalNodeIntf captures common properties for internal nodes: single IP address
+// Implemented by NetworkInterface, IKSNode, ReservedIP (embedding InternalNode)
 type InternalNodeIntf interface {
 	// an InternalNodeIntf has an exact one IP Address
 	Address() string
@@ -92,7 +93,7 @@ type InternalNodeIntf interface {
 // InternalNode implements interface InternalNodeIntf
 type InternalNode struct {
 	AddressStr string
-	IPBlockObj *common.IPBlock `json:"-"`
+	IPBlockObj *common.IPBlock `json:"-"` // avoid having this field in the JSON output
 }
 
 func (n *InternalNode) Address() string {

--- a/pkg/vpcmodel/abstractVPC.go
+++ b/pkg/vpcmodel/abstractVPC.go
@@ -28,7 +28,7 @@ type VPCResource struct {
 	ResourceType string
 	Zone         string
 	// the VPC to which this resource belongs to
-	VPCRef VPCResourceIntf `json:"-"` // avoid having this field in the JSON output
+	VPCRef VPCResourceIntf `json:"-"`
 }
 
 func (n *VPCResource) Name() string {
@@ -95,8 +95,8 @@ type InternalNodeIntf interface {
 type InternalNode struct {
 	// AddressStr is an IPv4 string, as the node's IP Address
 	AddressStr string
-	// IPBlockObj is an IPBlock object of the node's address (created from AddressStr)
-	// `json:"-"` is to avoid having this field in the JSON output (nodes connectivity output in JSON format),
+	// IPBlockObj is an IPBlock object of the node's address (created from AddressStr).
+	// This field is skipped in the JSON output (nodes connectivity output in JSON format),
 	// since it is sufficient to have the AddressStr, and no need to represent IPBlockObj as another
 	// attribute in the JSON output.
 	IPBlockObj *common.IPBlock `json:"-"`

--- a/pkg/vpcmodel/drawioGenerator.go
+++ b/pkg/vpcmodel/drawioGenerator.go
@@ -87,7 +87,7 @@ func (g *groupedExternalNodes) GenerateDrawioTreeNode(gen *DrawioGenerator) draw
 	}
 	tooltip := []string{}
 	for _, n := range *g {
-		tooltip = append(tooltip, n.(*ExternalNetwork).CidrStr)
+		tooltip = append(tooltip, n.CidrStr)
 	}
 	name := "Various IP ranges"
 	if all, _ := isEntirePublicInternetRange(*g); all {

--- a/pkg/vpcmodel/externalNetwork.go
+++ b/pkg/vpcmodel/externalNetwork.go
@@ -157,10 +157,10 @@ func GetExternalNetworkNodes(disjointRefExternalIPBlocks []*common.IPBlock) ([]N
 	return res, nil
 }
 
-func isEntirePublicInternetRange(nodes []Node) (bool, error) {
+func isEntirePublicInternetRange(nodes []*ExternalNetwork) (bool, error) {
 	ipList := make([]string, len(nodes))
 	for i, n := range nodes {
-		ipList[i] = n.CidrOrAddress()
+		ipList[i] = n.CidrStr
 	}
 
 	_, nodesRanges, err := ipStringsToIPblocks(ipList)

--- a/pkg/vpcmodel/grouping.go
+++ b/pkg/vpcmodel/grouping.go
@@ -198,13 +198,12 @@ func (g *GroupConnLines) getGroupedEndpointsElems(grouped groupedEndpointsElems)
 
 // same as the previous function, for groupedExternalNodesMap
 func (g *GroupConnLines) getGroupedExternalNodes(grouped []Node) *groupedExternalNodes {
-	// Due to the canonical representation, grouped.String() and thus grouped.Name() will be identical
-	//  to equiv groupedExternalNodes
 	res := make(groupedExternalNodes, len(grouped))
 	for i := range grouped {
 		res[i] = grouped[i].(*ExternalNetwork)
 	}
-
+	// Due to the canonical representation, grouped.String() and thus grouped.Name() will be identical
+	//  to equiv groupedExternalNodes
 	if existingGrouped, ok := g.groupedExternalNodesMap[res.Name()]; ok {
 		return existingGrouped
 	}

--- a/pkg/vpcmodel/grouping.go
+++ b/pkg/vpcmodel/grouping.go
@@ -12,10 +12,10 @@ const commaSeparator = ","
 
 // for each line here can group list of external nodes to cidrs list as of one element
 // groupedNodesInfo contains the list of nodes to be grouped and their common connection properties
-type groupingConnections map[EndpointElem]map[string]*groupedNodesInfo
+type groupingConnections map[EndpointElem]map[string]*groupedExternalNodesInfo
 
-type groupedNodesInfo struct {
-	nodes            []*ExternalNetwork
+type groupedExternalNodesInfo struct {
+	nodes            groupedExternalNodes
 	commonProperties *groupedCommonProperties
 }
 
@@ -37,7 +37,7 @@ type groupedCommonProperties struct {
 	groupingStrKey string // the key used for grouping per connectivity lines or diff lines
 }
 
-func (g *groupedNodesInfo) appendNode(n *ExternalNetwork) {
+func (g *groupedExternalNodesInfo) appendNode(n *ExternalNetwork) {
 	g.nodes = append(g.nodes, n)
 }
 
@@ -60,7 +60,7 @@ func (g *groupingConnections) getGroupedConnLines(groupedConnLines *GroupConnLin
 }
 
 func newGroupingConnections() *groupingConnections {
-	res := groupingConnections(map[EndpointElem]map[string]*groupedNodesInfo{})
+	res := groupingConnections(map[EndpointElem]map[string]*groupedExternalNodesInfo{})
 	return &res
 }
 
@@ -210,10 +210,10 @@ func (g *GroupConnLines) getGroupedExternalNodes(grouped groupedExternalNodes) *
 func (g *groupingConnections) addPublicConnectivity(ep EndpointElem, commonProps *groupedCommonProperties, targetNode *ExternalNetwork) {
 	connKey := commonProps.groupingStrKey
 	if _, ok := (*g)[ep]; !ok {
-		(*g)[ep] = map[string]*groupedNodesInfo{}
+		(*g)[ep] = map[string]*groupedExternalNodesInfo{}
 	}
 	if _, ok := (*g)[ep][connKey]; !ok {
-		(*g)[ep][connKey] = &groupedNodesInfo{commonProperties: commonProps}
+		(*g)[ep][connKey] = &groupedExternalNodesInfo{commonProperties: commonProps}
 	}
 	(*g)[ep][connKey].appendNode(targetNode)
 }

--- a/pkg/vpcmodel/grouping_test.go
+++ b/pkg/vpcmodel/grouping_test.go
@@ -99,8 +99,8 @@ func newVPCConfigTest1() (*VPCConfig, *VPCConnectivity) {
 	res := &VPCConfig{Nodes: []Node{}}
 	res.Nodes = append(res.Nodes,
 		&mockNetIntf{cidr: "10.0.20.5/32", name: "vsi1"},
-		&mockNetIntf{cidr: "1.2.3.4/22", name: "public1", isPublic: true},
-		&mockNetIntf{cidr: "8.8.8.8/32", name: "public2", isPublic: true})
+		&ExternalNetwork{CidrStr: "1.2.3.4/22", isPublicInternet: true},
+		&ExternalNetwork{CidrStr: "8.8.8.8/32", isPublicInternet: true})
 
 	res.NodeSets = append(res.NodeSets, &mockSubnet{"10.0.20.0/22", "subnet1", []Node{res.Nodes[0]}})
 
@@ -114,8 +114,8 @@ func newVPCConfigTest2() (*VPCConfig, *VPCConnectivity) {
 	res := &VPCConfig{Nodes: []Node{}}
 	res.Nodes = append(res.Nodes,
 		&mockNetIntf{cidr: "10.0.20.5/32", name: "vsi1"},
-		&mockNetIntf{cidr: "1.2.3.4/22", name: "public1", isPublic: true},
-		&mockNetIntf{cidr: "8.8.8.8/32", name: "public2", isPublic: true},
+		&ExternalNetwork{CidrStr: "1.2.3.4/22", isPublicInternet: true},
+		&ExternalNetwork{CidrStr: "8.8.8.8/32", isPublicInternet: true},
 		&mockNetIntf{cidr: "10.0.20.6/32", name: "vsi2"})
 
 	res.NodeSets = append(res.NodeSets, &mockSubnet{"10.0.20.0/22", "subnet1", []Node{res.Nodes[0], res.Nodes[3]}})
@@ -171,8 +171,8 @@ func configStatefulGrouping() (*VPCConfig, *VPCConnectivity) {
 	res := &VPCConfig{Nodes: []Node{}}
 	res.Nodes = append(res.Nodes,
 		&mockNetIntf{cidr: "10.0.20.5/32", name: "vsi1"},
-		&mockNetIntf{cidr: "1.2.3.4/22", name: "public1", isPublic: true},
-		&mockNetIntf{cidr: "8.8.8.8/32", name: "public2", isPublic: true},
+		&ExternalNetwork{CidrStr: "1.2.3.4/22", isPublicInternet: true},
+		&ExternalNetwork{CidrStr: "8.8.8.8/32", isPublicInternet: true},
 		&mockNetIntf{cidr: "10.0.20.6/32", name: "vsi2"})
 
 	res.NodeSets = append(res.NodeSets, &mockSubnet{"10.0.20.0/22", "subnet1", []Node{res.Nodes[0], res.Nodes[3]}})
@@ -208,9 +208,8 @@ func configIPRange() (*VPCConfig, *VPCConnectivity) {
 	res := &VPCConfig{Nodes: []Node{}}
 	res.Nodes = append(res.Nodes,
 		&mockNetIntf{cidr: "10.0.20.5/32", name: "vsi1"},
-		&mockNetIntf{cidr: "1.2.3.0/24", name: "public1", isPublic: true},
-		&mockNetIntf{cidr: "1.2.4.0/24", name: "public2", isPublic: true})
-
+		&ExternalNetwork{CidrStr: "1.2.3.0/24", isPublicInternet: true},
+		&ExternalNetwork{CidrStr: "1.2.4.0/24", isPublicInternet: true})
 	res.NodeSets = append(res.NodeSets, &mockSubnet{"10.0.20.0/22", "subnet1", []Node{res.Nodes[0]}})
 
 	res1 := &VPCConnectivity{AllowedConnsCombined: GeneralConnectivityMap{}}

--- a/pkg/vpcmodel/semanticDiff.go
+++ b/pkg/vpcmodel/semanticDiff.go
@@ -131,10 +131,10 @@ func (c *VPCConfig) getAllowedConnectionsCombined(
 func (c *VPCConfig) getVPCResourceInfInOtherConfig(other *VPCConfig, ep VPCResourceIntf,
 	diffAnalysis diffAnalysisType) (res VPCResourceIntf, err error) {
 	if ep.IsExternal() {
-		var node Node
+		var node *ExternalNetwork
 		var ok bool
-		if node, ok = ep.(Node); ok {
-			nodeSameCidr := findNodeWithCidr(other.Nodes, ep.(Node).CidrOrAddress())
+		if node, ok = ep.(*ExternalNetwork); ok {
+			nodeSameCidr := findNodeWithCidr(other.Nodes, node.CidrStr)
 			return nodeSameCidr, nil
 		}
 		return nil, fmt.Errorf(castingNodeErr, node.Name())

--- a/pkg/vpcmodel/semanticDiff.go
+++ b/pkg/vpcmodel/semanticDiff.go
@@ -131,13 +131,11 @@ func (c *VPCConfig) getAllowedConnectionsCombined(
 func (c *VPCConfig) getVPCResourceInfInOtherConfig(other *VPCConfig, ep VPCResourceIntf,
 	diffAnalysis diffAnalysisType) (res VPCResourceIntf, err error) {
 	if ep.IsExternal() {
-		var node *ExternalNetwork
-		var ok bool
-		if node, ok = ep.(*ExternalNetwork); ok {
+		if node, ok := ep.(*ExternalNetwork); ok {
 			nodeSameCidr := findNodeWithCidr(other.Nodes, node.CidrStr)
 			return nodeSameCidr, nil
 		}
-		return nil, fmt.Errorf(castingNodeErr, node.Name())
+		return nil, fmt.Errorf(castingNodeErr, ep.Name())
 	}
 	// endpoint is a vsi or a subnet, depending on diffAnalysis value
 	if diffAnalysis == Vsis {


### PR DESCRIPTION
issue #397:
- Using `ExternalNetwork` instead of `Node` where possible (to minimize usage of `CidrOrAddress()`)
- Adding new type `InternalNode`  and interface `InternalNodeIntf`, to capture the common IP address property for internal nodes.