### PR TITLE
Running golangci-lint action according to docs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: ./go.mod
-      - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+          cache: false
+      - uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804
         with:
-          skip-cache: true
+          version: latest


### PR DESCRIPTION
According to the [Action docs](https://github.com/golangci/golangci-lint-action):
* It's the cache in `setup-go` that should be disabled
* The version of golangci-lint to use must be specified