### PR TITLE
store the information about filtered nodes (uids) while parsing

### DIFF
--- a/pkg/ibmvpc/parser.go
+++ b/pkg/ibmvpc/parser.go
@@ -54,7 +54,7 @@ func filterByVpcResourceGroupAndRegions(rc *datamodel.ResourcesContainerModel, v
 func VPCConfigsFromResources(rc *datamodel.ResourcesContainerModel, vpcID, resourceGroup string, regions []string, debug bool) (
 	map[string]*vpcmodel.VPCConfig, error) {
 	res := map[string]*vpcmodel.VPCConfig{} // map from VPC UID to its config
-	filteredOut := map[string]bool{}        // map from networkInterface UID to its config
+	filteredOut := map[string]bool{}        // store networkInterface UIDs filtered out by skipByVPC
 	var err error
 
 	// map to filter resources, if certain VPC, resource-group or region list to analyze is specified,
@@ -388,7 +388,7 @@ func ignoreFIPWarning(fipName, details string) string {
 }
 
 func warnSkippedFip(filteredOutUIDs map[string]bool, targetUID string, fip *datamodel.FloatingIP) {
-	if _, ok := filteredOutUIDs[targetUID]; !ok {
+	if !filteredOutUIDs[targetUID] {
 		fmt.Printf("warning: skip fip %s - could not find attached network interface\n", *fip.Name)
 	}
 }

--- a/pkg/ibmvpc/parser.go
+++ b/pkg/ibmvpc/parser.go
@@ -387,6 +387,12 @@ func ignoreFIPWarning(fipName, details string) string {
 	return fmt.Sprintf("warning: ignoring floatingIP %s: %s", fipName, details)
 }
 
+func warnSkippedFip(filteredOutUIDs map[string]bool, targetUID string, fip *datamodel.FloatingIP) {
+	if _, ok := filteredOutUIDs[targetUID]; !ok {
+		fmt.Printf("warning: skip fip %s - could not find attached network interface\n", *fip.Name)
+	}
+}
+
 func getFipConfig(
 	rc *datamodel.ResourcesContainerModel,
 	res map[string]*vpcmodel.VPCConfig,
@@ -427,9 +433,7 @@ func getFipConfig(
 		}
 
 		if len(srcNodes) == 0 {
-			if _, ok := filteredOutUIDs[targetUID]; !ok {
-				fmt.Printf("warning: skip fip %s - could not find attached network interface\n", *fip.Name)
-			}
+			warnSkippedFip(filteredOutUIDs, targetUID, fip)
 			continue // could not find network interface attached to configured fip -- skip that fip
 		}
 


### PR DESCRIPTION
storing the information about filtered nodes (uids), so that when parsing fip - can figure out if that is really a required warning, or just a fip configuration that should have been filtered