### PR TITLE
Layout overlap crash

### DIFF
--- a/pkg/drawio/layout.go
+++ b/pkg/drawio/layout.go
@@ -781,12 +781,12 @@ func (ly *layoutS) setGroupingIconLocations() {
 			gIcon.Location().xOffset = -gIcon.Location().xOffset
 		}
 	}
+	// set the y offset according to the number of icons in the cell:
 	for cell, cellIcons := range iconsInCell {
 		for i, gIcon := range cellIcons {
 			gIcon.Location().yOffset = cell.r.height() * (2*i - len(cellIcons) + 1) / (len(cellIcons) + 1) / 2
 		}
 	}
-
 }
 
 // ////////////////////////////////////////////////////////////////////////////////////////

--- a/pkg/drawio/layout.go
+++ b/pkg/drawio/layout.go
@@ -752,7 +752,7 @@ func (ly *layoutS) setGroupingIconLocations() {
 		r *row
 		c *col
 	}
-	iconsInCell := map[cell]int{}
+	iconsInCell := map[cell][]IconTreeNodeInterface{}
 	for _, tn := range getAllNodes(ly.network) {
 		if !tn.IsIcon() || !tn.(IconTreeNodeInterface).IsGroupingPoint() {
 			continue
@@ -765,8 +765,7 @@ func (ly *layoutS) setGroupingIconLocations() {
 		r, c := calcGroupingIconLocation(parentLocation, colleagueParentLocation)
 
 		gIcon.setLocation(newCellLocation(r, c))
-		gIcon.Location().yOffset = groupedIconsDistance * iconsInCell[cell{r, c}]
-		iconsInCell[cell{r, c}]++
+		iconsInCell[cell{r, c}] = append(iconsInCell[cell{r, c}], gIcon)
 		switch parent.visibility {
 		case theSubnet:
 			gIcon.Location().xOffset = gIcon.Location().firstCol.width() / 2
@@ -782,6 +781,12 @@ func (ly *layoutS) setGroupingIconLocations() {
 			gIcon.Location().xOffset = -gIcon.Location().xOffset
 		}
 	}
+	for cell, cellIcons := range iconsInCell {
+		for i, gIcon := range cellIcons {
+			gIcon.Location().yOffset = cell.r.height() * (2*i - len(cellIcons) + 1) / (len(cellIcons) + 1) / 2
+		}
+	}
+
 }
 
 // ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
fixing https://github.com/np-guard/vpc-network-config-analyzer/issues/515
the old code layout the group point like this:
![image](https://github.com/np-guard/vpc-network-config-analyzer/assets/82028281/b745bcc7-4b0e-40a2-8253-ced46ba488aa)
the new layout is:
![image](https://github.com/np-guard/vpc-network-config-analyzer/assets/82028281/6a328aea-e6a0-41d6-abfc-6329ac07c127)

