### PR TITLE
consistency in the return values of VPC.AddressRange() and VPC.AddressPrefixes()

### DIFF
--- a/pkg/ibmvpc/implicit_routing.go
+++ b/pkg/ibmvpc/implicit_routing.go
@@ -88,7 +88,7 @@ func pgwHasSource(src vpcmodel.Node, pgw *PublicGateway) bool {
 func (rt *systemImplicitRT) getPath(src vpcmodel.Node, dest *ipblock.IPBlock) vpcmodel.Path {
 	// TODO: split dest by disjoint ip-blocks of the vpc-config (the known destinations ip-blocks)
 
-	if dest.ContainedIn(rt.vpc.addressPrefixesIPBlock) {
+	if dest.ContainedIn(rt.vpc.AddressPrefixes()) {
 		// direct connection
 		return []*vpcmodel.Endpoint{{VpcResource: src}, {IPBlock: dest}}
 	}

--- a/pkg/ibmvpc/vpc.go
+++ b/pkg/ibmvpc/vpc.go
@@ -133,8 +133,8 @@ func (v *VPC) Region() *Region {
 	return v.region
 }
 
-func (v *VPC) AddressPrefixes() []string {
-	return v.addressPrefixes
+func (v *VPC) AddressPrefixes() *ipblock.IPBlock {
+	return v.addressPrefixesIPBlock
 }
 
 func (v *VPC) getZoneByName(name string) (*Zone, error) {

--- a/pkg/vpcmodel/abstractVPC.go
+++ b/pkg/vpcmodel/abstractVPC.go
@@ -189,7 +189,7 @@ type NodeSet interface {
 
 type VPC interface {
 	NodeSet
-	AddressPrefixes() []string
+	AddressPrefixes() *ipblock.IPBlock
 }
 
 type Subnet interface {


### PR DESCRIPTION
change return value of VPC.AddressPrefixes() to return *ipblock.IPBlock