### PR TITLE
Update for-loop linters for go version 1.22+

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,13 +72,13 @@ linters:
     - bidichk
     - bodyclose
     - contextcheck
+    - copyloopvar
     - dogsled
     - dupl
     - durationcheck
     - errcheck
     - errname
     - errorlint
-    - exportloopref
     - funlen
     - ginkgolinter
     - gochecknoinits

--- a/cmd/analyzer/main_test.go
+++ b/cmd/analyzer/main_test.go
@@ -292,7 +292,6 @@ func TestCommandsFailExecute(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := _main(tt.args)
 			require.Contains(t, err.Error(), tt.expectedErrorContains,


### PR DESCRIPTION
fixes #836 