### PR TITLE
support explainability for public node square

### DIFF
--- a/pkg/drawio/connectivityMap.svg.tmpl
+++ b/pkg/drawio/connectivityMap.svg.tmpl
@@ -56,6 +56,7 @@
         {{ $ay := $data.AY $node}}
         <g id="{{$node.ID}}" clickable="true" selectable="{{$data.Clickable $node}}" title="{{$data.NodeName $node}}">
         <rect x="{{$data.Add $ax -3}}" y="{{$data.Add $ay -3 }}" width="{{$data.Add $node.Width 6}}" height="{{$data.Add $node.Height 6}}" fill="none" stroke="none" stroke-width="6" selection-marker="true" />
+        <title></title>
         {{if $data.IsFamily $node $data.Cnst.IbmSquare }}
                 <rect x="{{$ax}}" y="{{$ay}}" width="{{$node.Width}}" height="{{$node.Height}}" fill="none" stroke="{{$data.Color $node}}" pointer-events="all"/>
             {{if $data.HasImage $node}} 
@@ -78,7 +79,6 @@
                 {{ if $node.HasFip  }}
                     {{ $xTextOffset = 0 }}
                 {{end}}
-                <title></title>
                 <image x="{{$ax}}" y="{{$ay}}" width="{{$node.IconSize}}" height="{{$node.IconSize}}" opacity="0.{{$data.Opacity $node}}" xlink:href="data:image/svg+xml;base64,{{$data.Image $node}}"/>
                 <foreignObject  x="{{$data.Add $ax $xTextOffset}}" y="{{$data.Add $ay 40}}" width="120" height="70">
           				<p xmlns="http://www.w3.org/1999/xhtml" fill="rgb(0, 0, 0)" font-family="IBM Plex Sans" text-anchor="middle" font-size="14px">{{$data.SvgLabel $node}}</p>
@@ -210,9 +210,11 @@
                       else {
                         const src = selectedElems[0].getAttribute('id');
                         const dst = selectedElems[1].getAttribute('id');
+                        const other_src = jsObject[src]['otherIdForSelection'][0];
+                        const other_dst = jsObject[dst]['otherIdForSelection'][0];
                         const src_name = selectedElems[0].getAttribute('title');
                         const dst_name = selectedElems[1].getAttribute('title');
-                        const entry = xmlDoc.querySelector("entry[src='"+src+"'][dst='"+dst+"']");
+                        const entry = xmlDoc.querySelector("entry[src='"+other_src+"'][dst='"+other_dst+"']");
                         savedTooltip = selectedElems[1].getElementsByTagName("title")[0].textContent
                         if (entry) {
 							            explainTitle = 'Configurations affecting the connectivity between <span style="background-color: yellow;">'+src_name+'</span> and <span style="background-color: #ADD8E6;">'+dst_name+'</span>:\n' 

--- a/pkg/drawio/connectivityMap.svg.tmpl
+++ b/pkg/drawio/connectivityMap.svg.tmpl
@@ -160,13 +160,21 @@
                         explainText + '\n'+
                         '<span style="color: deepPink; font-size: 14px; ">'+explainExplainText+'</span>\n'
                 }
+                function markElement(element, color) {
+                    const markerElement = element.querySelector('[selection-marker]')
+                    markerElement.setAttribute('stroke', color);
+				            const elementID =  element.getAttribute('id')
+				            const otherelementID = jsObject[elementID]['otherIdForMarking'][0];
+				            const otherElement = Array.from(selectableElems).find(e => e.getAttribute('id') == otherelementID);
+                    const otherMarkerElement = otherElement.querySelector('[selection-marker]')
+                    otherMarkerElement.setAttribute('stroke', color);
+				        }
 
                 function selectExplPeer(event) {
                   let nodeElement = event.target;
                   while (nodeElement && !nodeElement.hasAttribute('selectable')) {
                     nodeElement = nodeElement.parentNode;
                   }
-                  const markerElement = nodeElement.querySelector('[selection-marker]')
                   clickFlag = true;
                   setTimeout(function() {
                     // If clickFlag is still true after the timer, trigger single-click action
@@ -175,25 +183,24 @@
                       selectedElems[1].getElementsByTagName("title")[0].textContent = savedTooltip
                         selectedElems.forEach((item) => {
                           item.classList.remove('selected');
-                          const markerElement = item.querySelector('[selection-marker]')
-                          markerElement.setAttribute('stroke', 'none');
+                          markElement(item, 'none');
                         });
                         selectedElems.length = 0;
                       }
                       if (nodeElement.classList.contains('selected')) {
                               // If the clicked element is already selected, deselect it
                               nodeElement.classList.remove('selected');
-                              markerElement.setAttribute('stroke', 'none');
+                              markElement(nodeElement, 'none');
                               selectedElems.splice(selectedElems.indexOf(nodeElement), 1);
                       }
                       else if (selectedElems.length < 2) {
                         // If less than 2 elements are selected, select the clicked element
                         nodeElement.classList.add('selected');
                         if (selectedElems.length === 0) {  // src
-                          markerElement.setAttribute('stroke', 'yellow');
+                          markElement(nodeElement, 'yellow');
                         }
                         else { // dst
-                          markerElement.setAttribute('stroke', '#ADD8E6');
+                          markElement(nodeElement, '#ADD8E6');
                         }
                         selectedElems.push(nodeElement);
                       }

--- a/pkg/drawio/connectivityMap.svg.tmpl
+++ b/pkg/drawio/connectivityMap.svg.tmpl
@@ -164,10 +164,12 @@
                     const markerElement = element.querySelector('[selection-marker]')
                     markerElement.setAttribute('stroke', color);
 				            const elementID =  element.getAttribute('id')
-				            const otherelementID = jsObject[elementID]['otherIdForMarking'][0];
-				            const otherElement = Array.from(selectableElems).find(e => e.getAttribute('id') == otherelementID);
-                    const otherMarkerElement = otherElement.querySelector('[selection-marker]')
-                    otherMarkerElement.setAttribute('stroke', color);
+                    if (jsObject[elementID].hasOwnProperty('otherIdForMarking')){
+				              const otherelementID = jsObject[elementID]['otherIdForMarking'][0];
+				              const otherElement = Array.from(selectableElems).find(e => e.getAttribute('id') == otherelementID);
+                      const otherMarkerElement = otherElement.querySelector('[selection-marker]')
+                      otherMarkerElement.setAttribute('stroke', color);
+                    }
 				        }
 
                 function selectExplPeer(event) {
@@ -215,13 +217,17 @@
                         explainExplainText =  selectDstText;
                       }
                       else {
-                        const src = selectedElems[0].getAttribute('id');
-                        const dst = selectedElems[1].getAttribute('id');
-                        const src_for_selection = jsObject[src]['idForSelection'][0];
-                        const dst_for_selection = jsObject[dst]['idForSelection'][0];
+                        src = selectedElems[0].getAttribute('id');
+                        dst = selectedElems[1].getAttribute('id');
+                        if (jsObject[src].hasOwnProperty('idForSelection')) {
+                          src = jsObject[src]['idForSelection'][0];
+                        }
+                        if (jsObject[dst].hasOwnProperty('idForSelection')) {
+                          dst = jsObject[dst]['idForSelection'][0];
+                        }
                         const src_name = selectedElems[0].getAttribute('title');
                         const dst_name = selectedElems[1].getAttribute('title');
-                        const entry = xmlDoc.querySelector("entry[src='"+src_for_selection+"'][dst='"+dst_for_selection+"']");
+                        const entry = xmlDoc.querySelector("entry[src='"+src+"'][dst='"+dst+"']");
                         savedTooltip = selectedElems[1].getElementsByTagName("title")[0].textContent
                         if (entry) {
 							            explainTitle = 'Configurations affecting the connectivity between <span style="background-color: yellow;">'+src_name+'</span> and <span style="background-color: #ADD8E6;">'+dst_name+'</span>:\n' 

--- a/pkg/drawio/connectivityMap.svg.tmpl
+++ b/pkg/drawio/connectivityMap.svg.tmpl
@@ -230,7 +230,7 @@
                         const entry = xmlDoc.querySelector("entry[src='"+src+"'][dst='"+dst+"']");
                         savedTooltip = selectedElems[1].getElementsByTagName("title")[0].textContent
                         if (entry) {
-							            explainTitle = 'Configurations affecting the connectivity between <span style="background-color: yellow;">'+src_name+'</span> and <span style="background-color: #ADD8E6;">'+dst_name+'</span>:\n' 
+							            explainTitle = 'Explaining connectivity from <span style="background-color: yellow;">'+src_name+'</span> to <span style="background-color: #ADD8E6;">'+dst_name+'</span>:\n' 
 
                           // color the src and dst names
                           explainText = explainTitle + entry.textContent;

--- a/pkg/drawio/connectivityMap.svg.tmpl
+++ b/pkg/drawio/connectivityMap.svg.tmpl
@@ -217,11 +217,11 @@
                       else {
                         const src = selectedElems[0].getAttribute('id');
                         const dst = selectedElems[1].getAttribute('id');
-                        const other_src = jsObject[src]['otherIdForSelection'][0];
-                        const other_dst = jsObject[dst]['otherIdForSelection'][0];
+                        const src_for_selection = jsObject[src]['idForSelection'][0];
+                        const dst_for_selection = jsObject[dst]['idForSelection'][0];
                         const src_name = selectedElems[0].getAttribute('title');
                         const dst_name = selectedElems[1].getAttribute('title');
-                        const entry = xmlDoc.querySelector("entry[src='"+other_src+"'][dst='"+other_dst+"']");
+                        const entry = xmlDoc.querySelector("entry[src='"+src_for_selection+"'][dst='"+dst_for_selection+"']");
                         savedTooltip = selectedElems[1].getElementsByTagName("title")[0].textContent
                         if (entry) {
 							            explainTitle = 'Configurations affecting the connectivity between <span style="background-color: yellow;">'+src_name+'</span> and <span style="background-color: #ADD8E6;">'+dst_name+'</span>:\n' 

--- a/pkg/drawio/createMapFile.go
+++ b/pkg/drawio/createMapFile.go
@@ -84,6 +84,7 @@ func newTemplateData(network SquareTreeNodeInterface, explanations []Explanation
 			data.clickable[e.Src] = true
 			data.clickable[e.Dst] = true
 		}
+		data.clickable[network.(*NetworkTreeNode).publicNetwork] = true
 	}
 	return data
 }

--- a/pkg/drawio/nodesRelations.go
+++ b/pkg/drawio/nodesRelations.go
@@ -31,7 +31,7 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 		}
 		res[nodeID]["relations"] = nodeRelations
 		res[nodeID]["graphExplanation"] = []string{"Connectivity graph of " + data.NodeName(node)}
-		res[nodeID]["otherIdForSelection"] = []string{nodeID}
+		res[nodeID]["idForSelection"] = []string{nodeID}
 		res[nodeID]["otherIdForMarking"] = []string{nodeID}
 	}
 	if network.(*NetworkTreeNode).publicNetwork != nil {
@@ -39,7 +39,7 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 		if publicNetworkIcon != nil {
 			publicNetworkSquareID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.ID())
 			publicNetworkIconID := common.UintToString(publicNetworkIcon.ID())
-			res[publicNetworkSquareID]["otherIdForSelection"] = []string{publicNetworkIconID}
+			res[publicNetworkSquareID]["idForSelection"] = []string{publicNetworkIconID}
 			if !publicNetworkIcon.NotShownInDrawio() {
 				res[publicNetworkSquareID]["otherIdForMarking"] = []string{publicNetworkIconID}
 				res[publicNetworkIconID]["otherIdForMarking"] = []string{publicNetworkSquareID}

--- a/pkg/drawio/nodesRelations.go
+++ b/pkg/drawio/nodesRelations.go
@@ -31,9 +31,13 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 		}
 		res[nodeID]["relations"] = nodeRelations
 		res[nodeID]["graphExplanation"] = []string{"Connectivity graph of " + data.NodeName(node)}
-		res[nodeID]["idForSelection"] = []string{nodeID}
-		res[nodeID]["otherIdForMarking"] = []string{nodeID}
 	}
+	setPublicNetworkRelation(network, res)
+	b, _ := json.Marshal(res)
+	data.Relations = string(b)
+}
+
+func setPublicNetworkRelation(network TreeNodeInterface, res map[string]map[string][]string) {
 	if network.(*NetworkTreeNode).publicNetwork != nil {
 		publicNetworkIcon := network.(*NetworkTreeNode).publicNetwork.(*PublicNetworkTreeNode).PublicNetworkIcon
 		if publicNetworkIcon != nil {
@@ -46,8 +50,6 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 			}
 		}
 	}
-	b, _ := json.Marshal(res)
-	data.Relations = string(b)
 }
 
 // setNodesNames() set the name of each node

--- a/pkg/drawio/nodesRelations.go
+++ b/pkg/drawio/nodesRelations.go
@@ -32,10 +32,13 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 		res[nodeID]["relations"] = nodeRelations
 		res[nodeID]["graphExplanation"] = []string{"Connectivity graph of " + data.NodeName(node)}
 		res[nodeID]["otherIdForSelection"] = []string{nodeID}
+		res[nodeID]["otherIdForMarking"] = []string{nodeID}
 	}
 	publicNetworkSquareID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.ID())
 	publicNetworkIconID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.(*PublicNetworkTreeNode).PublicNetworkIcon.ID())
 	res[publicNetworkSquareID]["otherIdForSelection"] = []string{publicNetworkIconID}
+	res[publicNetworkSquareID]["otherIdForMarking"] = []string{publicNetworkIconID}
+	res[publicNetworkIconID]["otherIdForMarking"] = []string{publicNetworkSquareID}
 	b, _ := json.Marshal(res)
 	data.Relations = string(b)
 }

--- a/pkg/drawio/nodesRelations.go
+++ b/pkg/drawio/nodesRelations.go
@@ -40,8 +40,10 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 			publicNetworkSquareID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.ID())
 			publicNetworkIconID := common.UintToString(publicNetworkIcon.ID())
 			res[publicNetworkSquareID]["otherIdForSelection"] = []string{publicNetworkIconID}
-			res[publicNetworkSquareID]["otherIdForMarking"] = []string{publicNetworkIconID}
-			res[publicNetworkIconID]["otherIdForMarking"] = []string{publicNetworkSquareID}
+			if !publicNetworkIcon.NotShownInDrawio() {
+				res[publicNetworkSquareID]["otherIdForMarking"] = []string{publicNetworkIconID}
+				res[publicNetworkIconID]["otherIdForMarking"] = []string{publicNetworkSquareID}
+			}
 		}
 	}
 	b, _ := json.Marshal(res)

--- a/pkg/drawio/nodesRelations.go
+++ b/pkg/drawio/nodesRelations.go
@@ -19,7 +19,7 @@ const (
 	relations         = "relations"
 	graphExplanation  = "graphExplanation"
 	idForSelection    = "idForSelection"
-	otherIdForMarking = "otherIdForMarking"
+	otherIDForMarking = "otherIdForMarking"
 )
 
 //////////////////////////////////////////////////////////////////////
@@ -52,8 +52,8 @@ func setPublicNetworkRelation(network TreeNodeInterface, res map[string]map[stri
 			publicNetworkIconID := common.UintToString(publicNetworkIcon.ID())
 			res[publicNetworkSquareID][idForSelection] = []string{publicNetworkIconID}
 			if !publicNetworkIcon.NotShownInDrawio() {
-				res[publicNetworkSquareID][otherIdForMarking] = []string{publicNetworkIconID}
-				res[publicNetworkIconID][otherIdForMarking] = []string{publicNetworkSquareID}
+				res[publicNetworkSquareID][otherIDForMarking] = []string{publicNetworkIconID}
+				res[publicNetworkIconID][otherIDForMarking] = []string{publicNetworkSquareID}
 			}
 		}
 	}

--- a/pkg/drawio/nodesRelations.go
+++ b/pkg/drawio/nodesRelations.go
@@ -34,11 +34,16 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 		res[nodeID]["otherIdForSelection"] = []string{nodeID}
 		res[nodeID]["otherIdForMarking"] = []string{nodeID}
 	}
-	publicNetworkSquareID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.ID())
-	publicNetworkIconID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.(*PublicNetworkTreeNode).PublicNetworkIcon.ID())
-	res[publicNetworkSquareID]["otherIdForSelection"] = []string{publicNetworkIconID}
-	res[publicNetworkSquareID]["otherIdForMarking"] = []string{publicNetworkIconID}
-	res[publicNetworkIconID]["otherIdForMarking"] = []string{publicNetworkSquareID}
+	if network.(*NetworkTreeNode).publicNetwork != nil {
+		publicNetworkIcon := network.(*NetworkTreeNode).publicNetwork.(*PublicNetworkTreeNode).PublicNetworkIcon
+		if publicNetworkIcon != nil {
+			publicNetworkSquareID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.ID())
+			publicNetworkIconID := common.UintToString(publicNetworkIcon.ID())
+			res[publicNetworkSquareID]["otherIdForSelection"] = []string{publicNetworkIconID}
+			res[publicNetworkSquareID]["otherIdForMarking"] = []string{publicNetworkIconID}
+			res[publicNetworkIconID]["otherIdForMarking"] = []string{publicNetworkSquareID}
+		}
+	}
 	b, _ := json.Marshal(res)
 	data.Relations = string(b)
 }

--- a/pkg/drawio/nodesRelations.go
+++ b/pkg/drawio/nodesRelations.go
@@ -15,6 +15,13 @@ import (
 	"github.com/np-guard/vpc-network-config-analyzer/pkg/common"
 )
 
+const (
+	relations         = "relations"
+	graphExplanation  = "graphExplanation"
+	idForSelection    = "idForSelection"
+	otherIdForMarking = "otherIdForMarking"
+)
+
 //////////////////////////////////////////////////////////////////////
 // setNodesRelations() set for each node N, what are the related nodes to be displayed when the html is filtered by N
 /////////////////////////////////////////////////////////////////////////////
@@ -29,8 +36,8 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 		for _, n := range rel[node] {
 			nodeRelations = append(nodeRelations, common.UintToString(n.ID()))
 		}
-		res[nodeID]["relations"] = nodeRelations
-		res[nodeID]["graphExplanation"] = []string{"Connectivity graph of " + data.NodeName(node)}
+		res[nodeID][relations] = nodeRelations
+		res[nodeID][graphExplanation] = []string{"Connectivity graph of " + data.NodeName(node)}
 	}
 	setPublicNetworkRelation(network, res)
 	b, _ := json.Marshal(res)
@@ -43,10 +50,10 @@ func setPublicNetworkRelation(network TreeNodeInterface, res map[string]map[stri
 		if publicNetworkIcon != nil {
 			publicNetworkSquareID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.ID())
 			publicNetworkIconID := common.UintToString(publicNetworkIcon.ID())
-			res[publicNetworkSquareID]["idForSelection"] = []string{publicNetworkIconID}
+			res[publicNetworkSquareID][idForSelection] = []string{publicNetworkIconID}
 			if !publicNetworkIcon.NotShownInDrawio() {
-				res[publicNetworkSquareID]["otherIdForMarking"] = []string{publicNetworkIconID}
-				res[publicNetworkIconID]["otherIdForMarking"] = []string{publicNetworkSquareID}
+				res[publicNetworkSquareID][otherIdForMarking] = []string{publicNetworkIconID}
+				res[publicNetworkIconID][otherIdForMarking] = []string{publicNetworkSquareID}
 			}
 		}
 	}

--- a/pkg/drawio/nodesRelations.go
+++ b/pkg/drawio/nodesRelations.go
@@ -31,7 +31,11 @@ func (data *templateData) setNodesRelations(network TreeNodeInterface) {
 		}
 		res[nodeID]["relations"] = nodeRelations
 		res[nodeID]["graphExplanation"] = []string{"Connectivity graph of " + data.NodeName(node)}
+		res[nodeID]["otherIdForSelection"] = []string{nodeID}
 	}
+	publicNetworkSquareID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.ID())
+	publicNetworkIconID := common.UintToString(network.(*NetworkTreeNode).publicNetwork.(*PublicNetworkTreeNode).PublicNetworkIcon.ID())
+	res[publicNetworkSquareID]["otherIdForSelection"] = []string{publicNetworkIconID}
 	b, _ := json.Marshal(res)
 	data.Relations = string(b)
 }

--- a/pkg/drawio/squareTreeNode.go
+++ b/pkg/drawio/squareTreeNode.go
@@ -108,7 +108,7 @@ type PublicNetworkTreeNode struct {
 }
 
 func NewPublicNetworkTreeNode(parent *NetworkTreeNode) *PublicNetworkTreeNode {
-	pn := &PublicNetworkTreeNode{abstractSquareTreeNode: newAbstractSquareTreeNode(parent, "Public\nNetwork")}
+	pn := &PublicNetworkTreeNode{abstractSquareTreeNode: newAbstractSquareTreeNode(parent, "Public Network")}
 	parent.publicNetwork = pn
 	return pn
 }

--- a/pkg/drawio/squareTreeNode.go
+++ b/pkg/drawio/squareTreeNode.go
@@ -104,6 +104,7 @@ func (tn *NetworkTreeNode) children() ([]SquareTreeNodeInterface, []IconTreeNode
 // ////////////////////////////////////////////////////////////////
 type PublicNetworkTreeNode struct {
 	abstractSquareTreeNode
+	PublicNetworkIcon TreeNodeInterface
 }
 
 func NewPublicNetworkTreeNode(parent *NetworkTreeNode) *PublicNetworkTreeNode {

--- a/pkg/vpcmodel/drawioOutput.go
+++ b/pkg/vpcmodel/drawioOutput.go
@@ -106,6 +106,18 @@ func (d *DrawioOutputFormatter) createNodeSets() {
 func (d *DrawioOutputFormatter) createNodes() {
 	if d.cConfigs.publicNetworkNode != nil {
 		d.gen.publicNetwork.PublicNetworkIcon = d.gen.TreeNode(d.cConfigs.publicNetworkNode)
+		showPublicNetworkIconOnDrawio := false
+		for _, vpcConn := range d.gConns {
+			for _, line := range vpcConn.GroupedLines {
+				if line.Src == d.cConfigs.publicNetworkNode || line.Dst == d.cConfigs.publicNetworkNode {
+					showPublicNetworkIconOnDrawio = true
+
+				}
+			}
+		}
+		if !showPublicNetworkIconOnDrawio {
+			d.gen.publicNetwork.PublicNetworkIcon.SetNotShownInDrawio()
+		}
 	}
 	for _, vpcConfig := range d.cConfigs.Configs() {
 		if !vpcConfig.IsMultipleVPCsConfig {

--- a/pkg/vpcmodel/drawioOutput.go
+++ b/pkg/vpcmodel/drawioOutput.go
@@ -118,10 +118,11 @@ func (d *DrawioOutputFormatter) createNodes() {
 
 // createPublicNetworkIcon() - will always create the the iconTreeNode that represent the Public Network
 // in case that it has no connection, we will not show it in drawio
-// (it is still needed in the html, since it holds the explainability information)
+// however, we always create it since it's needed for holding the explainability information of the public network square
 func (d *DrawioOutputFormatter) createPublicNetworkIcon() {
 	if d.cConfigs.publicNetworkNode != nil {
 		d.gen.publicNetwork.PublicNetworkIcon = d.gen.TreeNode(d.cConfigs.publicNetworkNode)
+		// check if to show the icon, only if it is a src/dst:
 		publicIconHasConnection := false
 		for _, vpcConn := range d.gConns {
 			if slices.IndexFunc(vpcConn.GroupedLines, func(line *groupedConnLine) bool {

--- a/pkg/vpcmodel/drawioOutput.go
+++ b/pkg/vpcmodel/drawioOutput.go
@@ -104,8 +104,9 @@ func (d *DrawioOutputFormatter) createNodeSets() {
 }
 
 func (d *DrawioOutputFormatter) createNodes() {
-	d.cConfigs.publicNetworkNode = getPublicNetworkNode()
-	d.gen.publicNetwork.PublicNetworkIcon = d.gen.TreeNode(d.cConfigs.publicNetworkNode)
+	if d.cConfigs.publicNetworkNode != nil {
+		d.gen.publicNetwork.PublicNetworkIcon = d.gen.TreeNode(d.cConfigs.publicNetworkNode)
+	}
 	for _, vpcConfig := range d.cConfigs.Configs() {
 		if !vpcConfig.IsMultipleVPCsConfig {
 			for _, n := range vpcConfig.Nodes {

--- a/pkg/vpcmodel/drawioOutput.go
+++ b/pkg/vpcmodel/drawioOutput.go
@@ -120,21 +120,23 @@ func (d *DrawioOutputFormatter) createNodes() {
 // in case that it has no connection, we will not show it in drawio
 // however, we always create it since it's needed for holding the explainability information of the public network square
 func (d *DrawioOutputFormatter) createPublicNetworkIcon() {
-	if d.cConfigs.publicNetworkNode != nil {
-		d.gen.publicNetwork.PublicNetworkIcon = d.gen.TreeNode(d.cConfigs.publicNetworkNode)
-		// check if to show the icon, only if it is a src/dst:
-		publicIconHasConnection := false
-		for _, vpcConn := range d.gConns {
-			if slices.IndexFunc(vpcConn.GroupedLines, func(line *groupedConnLine) bool {
-				return line.Src == d.cConfigs.publicNetworkNode || line.Dst == d.cConfigs.publicNetworkNode
-			}) >= 0 {
-				publicIconHasConnection = true
-				break
-			}
+	if d.cConfigs.publicNetworkNode == nil {
+		return
+	}
+	d.gen.publicNetwork.PublicNetworkIcon = d.gen.TreeNode(d.cConfigs.publicNetworkNode)
+	// check if to show the icon, only if it is a src/dst:
+	publicIconHasConnection := false
+	for _, vpcConn := range d.gConns {
+		hasConnFunc := func(line *groupedConnLine) bool {
+			return line.Src == d.cConfigs.publicNetworkNode || line.Dst == d.cConfigs.publicNetworkNode
 		}
-		if !publicIconHasConnection {
-			d.gen.publicNetwork.PublicNetworkIcon.SetNotShownInDrawio()
+		if slices.IndexFunc(vpcConn.GroupedLines, hasConnFunc) >= 0 {
+			publicIconHasConnection = true
+			break
 		}
+	}
+	if !publicIconHasConnection {
+		d.gen.publicNetwork.PublicNetworkIcon.SetNotShownInDrawio()
 	}
 }
 

--- a/pkg/vpcmodel/drawioOutput.go
+++ b/pkg/vpcmodel/drawioOutput.go
@@ -104,6 +104,8 @@ func (d *DrawioOutputFormatter) createNodeSets() {
 }
 
 func (d *DrawioOutputFormatter) createNodes() {
+	d.cConfigs.publicNetworkNode = getPublicNetworkNode()
+	d.gen.publicNetwork.PublicNetworkIcon = d.gen.TreeNode(d.cConfigs.publicNetworkNode)
 	for _, vpcConfig := range d.cConfigs.Configs() {
 		if !vpcConfig.IsMultipleVPCsConfig {
 			for _, n := range vpcConfig.Nodes {

--- a/pkg/vpcmodel/multiExplainability.go
+++ b/pkg/vpcmodel/multiExplainability.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/np-guard/models/pkg/ipblock"
+	"github.com/np-guard/vpc-network-config-analyzer/pkg/drawio"
 )
 
 type explainInputEntry struct {
@@ -103,6 +104,17 @@ func (c *VPCConfig) getNodesFromEndpoint(endpoint EndpointElem) ([]Node, error) 
 			return nil, err
 		}
 		return disjointNodes, nil
+	case *allPublicNodes:
+		var externalIP = ipblock.New()
+		for _, e := range n.groupedExternalNodes {
+			externalIP = externalIP.Union(e.ipblock)
+		}
+		// gets external nodes from e as explained in getCidrExternalNodes
+		disjointNodes, _, err := c.getCidrExternalNodes(externalIP)
+		if err != nil {
+			return nil, err
+		}
+		return disjointNodes, nil
 	}
 	return nil, fmt.Errorf("np-Guard error: %v not of type InternalNodeIntf or groupedExternalNodes", endpoint.Name())
 }
@@ -174,10 +186,19 @@ func collectNodesForExplanation(cConfigs *MultipleVPCConfigs, conns map[string]*
 	for i := range gr {
 		gr[i] = ns[i].(*ExternalNetwork)
 	}
-	var g groupedExternalNodes = gr
+	g  := allPublicNodes{gr}
 	externalNodes[&g] = true
 
 	return internalNodes, externalNodes
+}
+
+type allPublicNodes struct{
+	groupedExternalNodes
+}
+func (g *allPublicNodes) ShowOnSubnetMode() bool  { return true }
+func (g *allPublicNodes) Kind() string  { return "xxxxxx" }
+func (g *allPublicNodes) GenerateDrawioTreeNode(gen *DrawioGenerator) drawio.TreeNodeInterface{
+	return gen.publicNetwork
 }
 
 func collectMultiConnectionsForExplanation(

--- a/pkg/vpcmodel/multiExplainability.go
+++ b/pkg/vpcmodel/multiExplainability.go
@@ -169,6 +169,14 @@ func collectNodesForExplanation(cConfigs *MultipleVPCConfigs, conns map[string]*
 			}
 		}
 	}
+	ns, _ := GetExternalNetworkNodes([]*ipblock.IPBlock{ipblock.GetCidrAll()})
+	gr := make([]*ExternalNetwork, len(ns))
+	for i := range gr {
+		gr[i] = ns[i].(*ExternalNetwork)
+	}
+	var g groupedExternalNodes = gr
+	externalNodes[&g] = true
+
 	return internalNodes, externalNodes
 }
 

--- a/pkg/vpcmodel/multiExplainability.go
+++ b/pkg/vpcmodel/multiExplainability.go
@@ -169,17 +169,18 @@ func collectNodesForExplanation(cConfigs *MultipleVPCConfigs, conns map[string]*
 			}
 		}
 	}
+	externalNodes[cConfigs.publicNetworkNode] = true
+	return internalNodes, externalNodes
+}
+func getPublicNetworkNode() EndpointElem {
 	ns, _ := GetExternalNetworkNodes([]*ipblock.IPBlock{ipblock.GetCidrAll()})
 	gr := make([]*ExternalNetwork, len(ns))
 	for i := range gr {
 		gr[i] = ns[i].(*ExternalNetwork)
 	}
-	g  := groupedExternalNodes(gr)
-	externalNodes[&g] = true
-
-	return internalNodes, externalNodes
+	g := groupedExternalNodes(gr)
+	return &g
 }
-
 
 func collectMultiConnectionsForExplanation(
 	cConfigs *MultipleVPCConfigs, conns map[string]*VPCConnectivity) map[EndpointElem]map[EndpointElem]*VPCConfig {

--- a/pkg/vpcmodel/multiExplainability.go
+++ b/pkg/vpcmodel/multiExplainability.go
@@ -174,15 +174,6 @@ func collectNodesForExplanation(cConfigs *MultipleVPCConfigs, conns map[string]*
 	}
 	return internalNodes, externalNodes
 }
-func getPublicNetworkNode() *groupedExternalNodes {
-	ns, _ := GetExternalNetworkNodes([]*ipblock.IPBlock{ipblock.GetCidrAll()})
-	gr := make([]*ExternalNetwork, len(ns))
-	for i := range gr {
-		gr[i] = ns[i].(*ExternalNetwork)
-	}
-	g := groupedExternalNodes(gr)
-	return &g
-}
 
 func collectMultiConnectionsForExplanation(
 	cConfigs *MultipleVPCConfigs, conns map[string]*VPCConnectivity) map[EndpointElem]map[EndpointElem]*VPCConfig {

--- a/pkg/vpcmodel/multiExplainability.go
+++ b/pkg/vpcmodel/multiExplainability.go
@@ -169,10 +169,12 @@ func collectNodesForExplanation(cConfigs *MultipleVPCConfigs, conns map[string]*
 			}
 		}
 	}
-	externalNodes[cConfigs.publicNetworkNode] = true
+	if cConfigs.publicNetworkNode != nil {
+		externalNodes[cConfigs.publicNetworkNode] = true
+	}
 	return internalNodes, externalNodes
 }
-func getPublicNetworkNode() EndpointElem {
+func getPublicNetworkNode() *groupedExternalNodes {
 	ns, _ := GetExternalNetworkNodes([]*ipblock.IPBlock{ipblock.GetCidrAll()})
 	gr := make([]*ExternalNetwork, len(ns))
 	for i := range gr {

--- a/pkg/vpcmodel/multi_vpc_config.go
+++ b/pkg/vpcmodel/multi_vpc_config.go
@@ -20,7 +20,7 @@ type MultipleVPCConfigs struct {
 	configs          map[string]*VPCConfig // a map from the vpc resource uid to the vpc config
 	toCompareConfigs map[string]*VPCConfig // a map from the vpc resource uid to the vpc config that we want to compare
 	provider         collector_common.Provider
-	// publicNetworkNode - the EndpointElem that  entire external cidr which is in any vpc:
+	// publicNetworkNode is an EndpointElem representing all public-internet CIDRs
 	publicNetworkNode EndpointElem
 }
 

--- a/pkg/vpcmodel/multi_vpc_config.go
+++ b/pkg/vpcmodel/multi_vpc_config.go
@@ -17,9 +17,9 @@ import (
 // Once multivpc support is elaborating , the struct may change
 // thus, please use get/set methods to access the structs; avoid direct access
 type MultipleVPCConfigs struct {
-	configs           map[string]*VPCConfig // a map from the vpc resource uid to the vpc config
-	toCompareConfigs  map[string]*VPCConfig // a map from the vpc resource uid to the vpc config that we want to compare
-	provider          collector_common.Provider
+	configs          map[string]*VPCConfig // a map from the vpc resource uid to the vpc config
+	toCompareConfigs map[string]*VPCConfig // a map from the vpc resource uid to the vpc config that we want to compare
+	provider         collector_common.Provider
 	// publicNetworkNode - the EndpointElem that represent all the cidr which are not in ant vpc:
 	publicNetworkNode EndpointElem
 }

--- a/pkg/vpcmodel/multi_vpc_config.go
+++ b/pkg/vpcmodel/multi_vpc_config.go
@@ -20,6 +20,7 @@ type MultipleVPCConfigs struct {
 	configs           map[string]*VPCConfig // a map from the vpc resource uid to the vpc config
 	toCompareConfigs  map[string]*VPCConfig // a map from the vpc resource uid to the vpc config that we want to compare
 	provider          collector_common.Provider
+	// publicNetworkNode - the EndpointElem that represent all the cidr which are not in ant vpc:
 	publicNetworkNode EndpointElem
 }
 

--- a/pkg/vpcmodel/multi_vpc_config.go
+++ b/pkg/vpcmodel/multi_vpc_config.go
@@ -17,13 +17,14 @@ import (
 // Once multivpc support is elaborating , the struct may change
 // thus, please use get/set methods to access the structs; avoid direct access
 type MultipleVPCConfigs struct {
-	configs          map[string]*VPCConfig // a map from the vpc resource uid to the vpc config
-	toCompareConfigs map[string]*VPCConfig // a map from the vpc resource uid to the vpc config that we want to compare
-	provider         collector_common.Provider
+	configs           map[string]*VPCConfig // a map from the vpc resource uid to the vpc config
+	toCompareConfigs  map[string]*VPCConfig // a map from the vpc resource uid to the vpc config that we want to compare
+	provider          collector_common.Provider
+	publicNetworkNode EndpointElem
 }
 
 func NewMultipleVPCConfigs(provider collector_common.Provider) *MultipleVPCConfigs {
-	return &MultipleVPCConfigs{map[string]*VPCConfig{}, nil, provider}
+	return &MultipleVPCConfigs{map[string]*VPCConfig{}, nil, provider, nil}
 }
 
 func (c *MultipleVPCConfigs) Configs() map[string]*VPCConfig {

--- a/pkg/vpcmodel/multi_vpc_config.go
+++ b/pkg/vpcmodel/multi_vpc_config.go
@@ -20,7 +20,7 @@ type MultipleVPCConfigs struct {
 	configs          map[string]*VPCConfig // a map from the vpc resource uid to the vpc config
 	toCompareConfigs map[string]*VPCConfig // a map from the vpc resource uid to the vpc config that we want to compare
 	provider         collector_common.Provider
-	// publicNetworkNode - the EndpointElem that represent all the cidr which are not in ant vpc:
+	// publicNetworkNode - the EndpointElem that  entire external cidr which is in any vpc:
 	publicNetworkNode EndpointElem
 }
 

--- a/pkg/vpcmodel/unifyGrouping.go
+++ b/pkg/vpcmodel/unifyGrouping.go
@@ -51,7 +51,7 @@ func unifyMultiVPC(configs *MultipleVPCConfigs, nodesConn map[string]*VPCConnect
 }
 func getPublicNetworkNode() *groupedExternalNodes {
 	ns, _ := GetExternalNetworkNodes([]*ipblock.IPBlock{ipblock.GetCidrAll()})
-	group  := groupedExternalNodes(make([]*ExternalNetwork, len(ns)))
+	group := groupedExternalNodes(make([]*ExternalNetwork, len(ns)))
 	for i := range group {
 		group[i] = ns[i].(*ExternalNetwork)
 	}

--- a/pkg/vpcmodel/unifyGrouping.go
+++ b/pkg/vpcmodel/unifyGrouping.go
@@ -46,6 +46,7 @@ func unifyMultiVPC(configs *MultipleVPCConfigs, nodesConn map[string]*VPCConnect
 			}
 		}
 	}
+	configs.publicNetworkNode = cache.getAndSetGroupedExternalFromCache(getPublicNetworkNode())
 }
 
 // cacheGroupedElements functionality

--- a/pkg/vpcmodel/unifyGrouping.go
+++ b/pkg/vpcmodel/unifyGrouping.go
@@ -9,6 +9,7 @@ package vpcmodel
 import (
 	"fmt"
 
+	"github.com/np-guard/models/pkg/ipblock"
 	"github.com/np-guard/vpc-network-config-analyzer/pkg/common"
 )
 
@@ -47,6 +48,14 @@ func unifyMultiVPC(configs *MultipleVPCConfigs, nodesConn map[string]*VPCConnect
 		}
 	}
 	configs.publicNetworkNode = cache.getAndSetGroupedExternalFromCache(getPublicNetworkNode())
+}
+func getPublicNetworkNode() *groupedExternalNodes {
+	ns, _ := GetExternalNetworkNodes([]*ipblock.IPBlock{ipblock.GetCidrAll()})
+	group  := groupedExternalNodes(make([]*ExternalNetwork, len(ns)))
+	for i := range group {
+		group[i] = ns[i].(*ExternalNetwork)
+	}
+	return &group
 }
 
 // cacheGroupedElements functionality


### PR DESCRIPTION
the solution is to always create a "public network" icon.
it holds the "public network" explainability information
if there is no connection, do not show in on the canvas.
